### PR TITLE
Support JUnit XML and TestEvent JSON output files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,15 @@ jobs:
       - setup_remote_docker
       - run:
           name: "Unit Test GO 1.10"
-          command: scripts/ci/test 1.10-alpine
+          command: |
+            scripts/ci/test 1.10-alpine
+            mkdir -p junit/gotest
+            docker cp \
+                test-$CIRCLE_BUILD_NUM:/go/src/gotest.tools/gotestsum/junit.xml \
+                junit/gotest/junit.xml
+
+      - store_test_results:
+          path: junit/
 
 workflows:
   version: 2

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/
 .dobi/
 .depsources
 dist/
+junit.xml

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -39,14 +39,35 @@
   version = "v0.8.0"
 
 [[projects]]
+  name = "github.com/sirupsen/logrus"
+  packages = ["."]
+  revision = "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
+  version = "v1.0.5"
+
+[[projects]]
   name = "github.com/spf13/pflag"
   packages = ["."]
   revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
   version = "v1.0.0"
 
+[[projects]]
+  branch = "master"
+  name = "golang.org/x/crypto"
+  packages = ["ssh/terminal"]
+  revision = "b49d69b5da943f7ef3c9cf91c8777c1f78a0cc3c"
+
+[[projects]]
+  branch = "master"
+  name = "golang.org/x/sys"
+  packages = [
+    "unix",
+    "windows"
+  ]
+  revision = "cbbc999da32df943dac6cd71eb3ee39e1d7838b9"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7894afe1a06268a2c2d22a4a61ca6fe8b1e8ce330c605ba0af9f05f68b3920e8"
+  inputs-digest = "f3ffd605e3c6dcf802b619e6a8110763cdf1130bfc3bada1501088210d26b6d2"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -23,3 +23,7 @@
   non-go = true
   go-tests = true
   unused-packages = true
+
+[[constraint]]
+  name = "github.com/sirupsen/logrus"
+  version = "1.0.5"

--- a/cmd/handler.go
+++ b/cmd/handler.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"io"
+
+	"os"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"gotest.tools/gotestsum/testjson"
+)
+
+type eventHandler struct {
+	formatter testjson.EventFormatter
+	out       io.Writer
+	err       io.Writer
+	jsonFile  io.WriteCloser
+}
+
+func (h *eventHandler) Err(text string) error {
+	_, err := h.err.Write([]byte(text + "\n"))
+	return err
+}
+
+func (h *eventHandler) Event(event testjson.TestEvent, execution *testjson.Execution) error {
+	if h.jsonFile != nil {
+		_, err := h.jsonFile.Write(event.Bytes())
+		if err != nil {
+			return errors.Wrap(err, "failed to write JSON file")
+		}
+	}
+
+	line, err := h.formatter(event, execution)
+	if err != nil {
+		return errors.Wrap(err, "failed to format event")
+	}
+	_, err = h.out.Write([]byte(line))
+	return errors.Wrap(err, "failed to write event")
+}
+
+func (h *eventHandler) Close() error {
+	if h.jsonFile != nil {
+		if err := h.jsonFile.Close(); err != nil {
+			log.WithError(err).Error("failed to close JSON file")
+		}
+	}
+	return nil
+}
+
+var _ testjson.EventHandler = &eventHandler{}
+
+func newEventHandler(opts *options, wout io.Writer, werr io.Writer) (*eventHandler, error) {
+	formatter := testjson.NewEventFormatter(opts.format)
+	if formatter == nil {
+		return nil, errors.Errorf("unknown format %s", opts.format)
+	}
+	handler := &eventHandler{
+		formatter: formatter,
+		out:       wout,
+		err:       werr,
+	}
+	var err error
+	if opts.jsonFile != "" {
+		handler.jsonFile, err = os.Create(opts.jsonFile)
+		if err != nil {
+			return handler, errors.Wrap(err, "failed to open JSON file")
+		}
+	}
+	return handler, nil
+}
+
+func writeJUnitFile(filename string, execution *testjson.Execution) error {
+	if filename == "" {
+		return nil
+	}
+	junitFile, err := os.Create(filename)
+	if err != nil {
+		return errors.Wrap(err, "failed to open JUnit file")
+	}
+	defer func() {
+		if err := junitFile.Close(); err != nil {
+			log.WithError(err).Error("failed to close JUnit file")
+		}
+	}()
+
+	// TODO: generate report
+	return nil
+}

--- a/cmd/handler.go
+++ b/cmd/handler.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"io"
-
 	"os"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+	"gotest.tools/gotestsum/internal/junitxml"
 	"gotest.tools/gotestsum/testjson"
 )
 
@@ -24,7 +24,7 @@ func (h *eventHandler) Err(text string) error {
 
 func (h *eventHandler) Event(event testjson.TestEvent, execution *testjson.Execution) error {
 	if h.jsonFile != nil {
-		_, err := h.jsonFile.Write(event.Bytes())
+		_, err := h.jsonFile.Write(append(event.Bytes(), '\n'))
 		if err != nil {
 			return errors.Wrap(err, "failed to write JSON file")
 		}
@@ -83,6 +83,5 @@ func writeJUnitFile(filename string, execution *testjson.Execution) error {
 		}
 	}()
 
-	// TODO: generate report
-	return nil
+	return junitxml.Write(junitFile, execution)
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -98,7 +98,7 @@ func run(opts *options) error {
 	if err != nil {
 		return err
 	}
-	defer handler.Close()
+	defer handler.Close() // nolint: errcheck
 	exec, err := testjson.ScanTestOutput(testjson.ScanConfig{
 		Stdout:  goTestProc.stdout,
 		Stderr:  goTestProc.stderr,

--- a/internal/junitxml/report.go
+++ b/internal/junitxml/report.go
@@ -61,8 +61,7 @@ type JUnitFailure struct {
 
 // Write creates an XML document and writes it to out.
 func Write(out io.Writer, exec *testjson.Execution) error {
-	doc := generate(exec)
-	return errors.Wrap(write(out, doc), "failed to write JUnit XML")
+	return errors.Wrap(write(out, generate(exec)), "failed to write JUnit XML")
 }
 
 func generate(exec *testjson.Execution) JUnitTestSuites {

--- a/internal/junitxml/report.go
+++ b/internal/junitxml/report.go
@@ -1,0 +1,135 @@
+/*Package junitxml creates a JUnit XML report from a testjson.Execution.
+ */
+package junitxml
+
+import (
+	"encoding/xml"
+	"io"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/pkg/errors"
+	"gotest.tools/gotestsum/testjson"
+)
+
+// JUnitTestSuites is a collection of JUnit test suites.
+type JUnitTestSuites struct {
+	XMLName xml.Name `xml:"testsuites"`
+	Suites  []JUnitTestSuite
+}
+
+// JUnitTestSuite is a single JUnit test suite which may contain many
+// testcases.
+type JUnitTestSuite struct {
+	XMLName    xml.Name        `xml:"testsuite"`
+	Tests      int             `xml:"tests,attr"`
+	Failures   int             `xml:"failures,attr"`
+	Time       string          `xml:"time,attr"`
+	Name       string          `xml:"name,attr"`
+	Properties []JUnitProperty `xml:"properties>property,omitempty"`
+	TestCases  []JUnitTestCase
+}
+
+// JUnitTestCase is a single test case with its result.
+type JUnitTestCase struct {
+	XMLName     xml.Name          `xml:"testcase"`
+	Classname   string            `xml:"classname,attr"`
+	Name        string            `xml:"name,attr"`
+	Time        string            `xml:"time,attr"`
+	SkipMessage *JUnitSkipMessage `xml:"skipped,omitempty"`
+	Failure     *JUnitFailure     `xml:"failure,omitempty"`
+}
+
+// JUnitSkipMessage contains the reason why a testcase was skipped.
+type JUnitSkipMessage struct {
+	Message string `xml:"message,attr"`
+}
+
+// JUnitProperty represents a key/value pair used to define properties.
+type JUnitProperty struct {
+	Name  string `xml:"name,attr"`
+	Value string `xml:"value,attr"`
+}
+
+// JUnitFailure contains data related to a failed test.
+type JUnitFailure struct {
+	Message  string `xml:"message,attr"`
+	Type     string `xml:"type,attr"`
+	Contents string `xml:",chardata"`
+}
+
+// Write creates an XML document and writes it to out.
+func Write(out io.Writer, exec *testjson.Execution) error {
+	doc := generate(exec)
+	return errors.Wrap(write(out, doc), "failed to write JUnit XML")
+}
+
+func generate(exec *testjson.Execution) JUnitTestSuites {
+	suites := JUnitTestSuites{}
+	for _, pkgname := range exec.Packages() {
+		pkg := exec.Package(pkgname)
+		junitpkg := JUnitTestSuite{
+			Name:       pkgname,
+			Tests:      pkg.Total,
+			Time:       testjson.FormatDurationAsSeconds(pkg.Elapsed(), 3),
+			Properties: packageProperties(),
+			TestCases:  packageTestCases(pkg),
+			Failures:   len(pkg.Failed),
+		}
+		suites.Suites = append(suites.Suites, junitpkg)
+	}
+	return suites
+}
+
+func packageProperties() []JUnitProperty {
+	return []JUnitProperty{
+		{Name: "go.version", Value: runtime.Version()},
+	}
+}
+
+func packageTestCases(pkg *testjson.Package) []JUnitTestCase {
+	cases := []JUnitTestCase{}
+
+	for _, tc := range pkg.Failed {
+		jtc := newJUnitTestCase(tc)
+		jtc.Failure = &JUnitFailure{
+			Message:  "Failed",
+			Contents: strings.Join(pkg.Output(tc.Test), ""),
+		}
+		cases = append(cases, jtc)
+	}
+
+	for _, tc := range pkg.Skipped {
+		jtc := newJUnitTestCase(tc)
+		jtc.SkipMessage = &JUnitSkipMessage{Message: strings.Join(pkg.Output(tc.Test), "")}
+		cases = append(cases, jtc)
+	}
+
+	for _, tc := range pkg.Passed {
+		jtc := newJUnitTestCase(tc)
+		cases = append(cases, jtc)
+	}
+	return cases
+}
+
+func newJUnitTestCase(tc testjson.TestCase) JUnitTestCase {
+	return JUnitTestCase{
+		Classname: filepath.Base(tc.Package),
+		Name:      tc.Test,
+		Time:      testjson.FormatDurationAsSeconds(tc.Elapsed, 3),
+	}
+}
+
+func write(out io.Writer, suites JUnitTestSuites) error {
+	doc, err := xml.MarshalIndent(suites, "", "\t")
+	if err != nil {
+		return err
+	}
+	_, err = out.Write([]byte(xml.Header))
+	if err != nil {
+		return err
+	}
+	_, err = out.Write(doc)
+	return err
+}

--- a/scripts/test-unit
+++ b/scripts/test-unit
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 set -eu -o pipefail
 
-paths=${@:-$(go list ./... | grep -v '/vendor/')}
+paths=${@:-./...}
 TESTFLAGS=${TESTFLAGS-}
 TESTTIMEOUT=${TESTTIMEOUT-30s}
-./dist/gotestsum --format short-verbose -- \
+./dist/gotestsum \
+    --junitfile junit.xml \
+    --format short-verbose -- \
     -test.timeout "$TESTTIMEOUT" $TESTFLAGS $paths

--- a/testjson/execution.go
+++ b/testjson/execution.go
@@ -60,14 +60,39 @@ func (e TestEvent) Bytes() []byte {
 
 // Package is the set of TestEvents for a single go package
 type Package struct {
-	run     int
-	failed  []TestCase
-	skipped []TestCase
-	//passed []time.Duration
-	output map[string][]string
+	Total   int
+	Failed  []TestCase
+	Skipped []TestCase
+	Passed  []TestCase
+	output  map[string][]string
 	// action identifies if the package passed or failed. A package may fail
 	// with no test failures if an init() or TestMain exits non-zero.
 	action Action
+}
+
+// Result returns if the package passed, failed, or was skipped because there
+// were no tests.
+func (p Package) Result() Action {
+	return p.action
+}
+
+// Elapsed returns the sum of the elapsed time for all tests in the package.
+func (p Package) Elapsed() time.Duration {
+	elapsed := time.Duration(0)
+	for _, testcase := range p.TestCases() {
+		elapsed = elapsed + testcase.Elapsed
+	}
+	return elapsed
+}
+
+// TestCases returns all the test cases.
+func (p Package) TestCases() []TestCase {
+	return append(append(p.Passed, p.Failed...), p.Skipped...)
+}
+
+// Output returns the full test output for a test.
+func (p Package) Output(test string) []string {
+	return p.output[test]
 }
 
 // TestCase stores the name and elapsed time for a test case.
@@ -106,30 +131,35 @@ func (e *Execution) add(event TestEvent) {
 
 	switch event.Action {
 	case ActionRun:
-		pkg.run++
+		pkg.Total++
 	case ActionFail:
-		pkg.failed = append(pkg.failed, TestCase{
+		pkg.Failed = append(pkg.Failed, TestCase{
 			Package: event.Package,
 			Test:    event.Test,
-			Elapsed: elapsedDuration(event),
+			Elapsed: elapsedDuration(event.Elapsed),
 		})
 	case ActionSkip:
-		pkg.skipped = append(pkg.skipped, TestCase{
+		pkg.Skipped = append(pkg.Skipped, TestCase{
 			Package: event.Package,
 			Test:    event.Test,
-			Elapsed: elapsedDuration(event),
+			Elapsed: elapsedDuration(event.Elapsed),
 		})
 	case ActionOutput, ActionBench:
 		// TODO: limit size of buffered test output
 		pkg.output[event.Test] = append(pkg.output[event.Test], event.Output)
 	case ActionPass:
+		pkg.Passed = append(pkg.Passed, TestCase{
+			Package: event.Package,
+			Test:    event.Test,
+			Elapsed: elapsedDuration(event.Elapsed),
+		})
 		// Remove test output once a test passes, it wont be used
 		pkg.output[event.Test] = nil
 	}
 }
 
-func elapsedDuration(event TestEvent) time.Duration {
-	return time.Duration(event.Elapsed*1000) * time.Millisecond
+func elapsedDuration(elapsed float64) time.Duration {
+	return time.Duration(elapsed*1000) * time.Millisecond
 }
 
 // Output returns the full test output for a test.
@@ -137,9 +167,14 @@ func (e *Execution) Output(pkg, test string) []string {
 	return e.packages[pkg].output[test]
 }
 
-// Package returns the Package for a TestEvent.
-func (e *Execution) Package(event TestEvent) *Package {
-	return e.packages[event.Package]
+// Package returns the Package by name.
+func (e *Execution) Package(name string) *Package {
+	return e.packages[name]
+}
+
+// Packages returns a sorted list of all package names.
+func (e *Execution) Packages() []string {
+	return sortedKeys(e.packages)
 }
 
 var clock = clockwork.NewRealClock()
@@ -156,10 +191,10 @@ func (e *Execution) Failed() []TestCase {
 		pkg := e.packages[name]
 
 		// Add package-level failure output if there were no failed tests.
-		if pkg.action == ActionFail && len(pkg.failed) == 0 {
+		if pkg.action == ActionFail && len(pkg.Failed) == 0 {
 			failed = append(failed, TestCase{Package: name})
 		} else {
-			failed = append(failed, pkg.failed...)
+			failed = append(failed, pkg.Failed...)
 		}
 	}
 	return failed
@@ -178,7 +213,7 @@ func sortedKeys(pkgs map[string]*Package) []string {
 func (e *Execution) Skipped() []TestCase {
 	var skipped []TestCase
 	for _, pkg := range sortedKeys(e.packages) {
-		skipped = append(skipped, e.packages[pkg].skipped...)
+		skipped = append(skipped, e.packages[pkg].Skipped...)
 	}
 	return skipped
 }
@@ -187,7 +222,7 @@ func (e *Execution) Skipped() []TestCase {
 func (e *Execution) Total() int {
 	total := 0
 	for _, pkg := range e.packages {
-		total += pkg.run
+		total += pkg.Total
 	}
 	return total
 }

--- a/testjson/execution_test.go
+++ b/testjson/execution_test.go
@@ -1,0 +1,24 @@
+package testjson
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gotestyourself/gotestyourself/assert"
+)
+
+func TestPackage_Elapsed(t *testing.T) {
+	pkg := &Package{
+		Failed: []TestCase{
+			{Elapsed: 300 * time.Millisecond},
+		},
+		Passed: []TestCase{
+			{Elapsed: 200 * time.Millisecond},
+			{Elapsed: 2500 * time.Millisecond},
+		},
+		Skipped: []TestCase{
+			{Elapsed: 100 * time.Millisecond},
+		},
+	}
+	assert.Equal(t, pkg.Elapsed(), 3100*time.Millisecond)
+}

--- a/testjson/printer.go
+++ b/testjson/printer.go
@@ -8,6 +8,10 @@ import (
 	"strings"
 )
 
+// EventFormatter is a function which handles an event and returns a string to
+// output for the event.
+type EventFormatter func(event TestEvent, output *Execution) (string, error)
+
 func debugFormat(event TestEvent, _ *Execution) (string, error) {
 	return fmt.Sprintf("%s %s %s (%.3f) [%d] %s\n",
 		event.Package,
@@ -149,8 +153,8 @@ func getPkgPathPrefix() string {
 
 var pkgPathPrefix = getPkgPathPrefix()
 
-// NewEventHandler returns a handler for printing events.
-func NewEventHandler(format string) HandleEvent {
+// NewEventFormatter returns a formatter for printing events.
+func NewEventFormatter(format string) EventFormatter {
 	switch format {
 	case "debug":
 		return debugFormat

--- a/testjson/printer.go
+++ b/testjson/printer.go
@@ -92,7 +92,7 @@ func shortFormat(event TestEvent, _ *Execution) (string, error) {
 		return "", nil
 	}
 	fmtElapsed := func() string {
-		d := elapsedDuration(event)
+		d := elapsedDuration(event.Elapsed)
 		if d == 0 {
 			return ""
 		}
@@ -114,12 +114,12 @@ func shortFormat(event TestEvent, _ *Execution) (string, error) {
 }
 
 func dotsFormat(event TestEvent, exec *Execution) (string, error) {
-	pkg := exec.Package(event)
+	pkg := exec.Package(event.Package)
 
 	switch {
 	case event.PackageEvent():
 		return "", nil
-	case event.Action == ActionRun && pkg.run == 1:
+	case event.Action == ActionRun && pkg.Total == 1:
 		return "[" + relativePackagePath(event.Package) + "]", nil
 	case event.Action == ActionPass:
 		return "·", nil

--- a/testjson/printer_test.go
+++ b/testjson/printer_test.go
@@ -85,22 +85,22 @@ var expectedExecution = &Execution{
 	errors:  []string{"internal/broken/broken.go:5:21: undefined: somepackage"},
 	packages: map[string]*Package{
 		"github.com/gotestyourself/gotestyourself/testjson/internal/good": {
-			run: 18,
-			skipped: []TestCase{
+			Total: 18,
+			Skipped: []TestCase{
 				{Test: "TestSkipped"},
 				{Test: "TestSkippedWitLog"},
 			},
 			action: ActionPass,
 		},
 		"github.com/gotestyourself/gotestyourself/testjson/internal/stub": {
-			run: 28,
-			failed: []TestCase{
+			Total: 28,
+			Failed: []TestCase{
 				{Test: "TestFailed"},
 				{Test: "TestFailedWithStderr"},
 				{Test: "TestNestedWithFailure/c"},
 				{Test: "TestNestedWithFailure"},
 			},
-			skipped: []TestCase{
+			Skipped: []TestCase{
 				{Test: "TestSkipped"},
 				{Test: "TestSkippedWitLog"},
 			},
@@ -121,6 +121,7 @@ var cmpExecutionShallow = gocmp.Options{
 var cmpPackageShallow = gocmp.Options{
 	// TODO: use opt.PathField(Package{}, "output")
 	gocmp.FilterPath(stringPath("packages.output"), gocmp.Ignore()),
+	gocmp.FilterPath(stringPath("packages.Passed"), gocmp.Ignore()),
 	gocmp.Comparer(func(x, y TestCase) bool {
 		return x.Test == y.Test
 	}),

--- a/testjson/printer_test.go
+++ b/testjson/printer_test.go
@@ -13,30 +13,39 @@ import (
 
 //go:generate ./generate.sh
 
-type scanConfigShim struct {
+type fakeHandler struct {
 	inputName string
-	handler   HandleEvent
-	Out       *bytes.Buffer
-	Err       *bytes.Buffer
+	formatter EventFormatter
+	out       *bytes.Buffer
+	err       *bytes.Buffer
 }
 
-func (s *scanConfigShim) Config(t *testing.T) ScanConfig {
+func (s *fakeHandler) Config(t *testing.T) ScanConfig {
 	return ScanConfig{
 		Stdout:  bytes.NewReader(golden.Get(t, s.inputName+".out")),
 		Stderr:  bytes.NewReader(golden.Get(t, s.inputName+".err")),
-		Out:     s.Out,
-		Err:     s.Err,
-		Handler: s.handler,
+		Handler: s,
 	}
 }
 
-func newConfigShim(handler HandleEvent, inputName string) *scanConfigShim {
-	return &scanConfigShim{
+func newFakeHandler(handler EventFormatter, inputName string) *fakeHandler {
+	return &fakeHandler{
 		inputName: inputName,
-		handler:   handler,
-		Out:       new(bytes.Buffer),
-		Err:       new(bytes.Buffer),
+		formatter: handler,
+		out:       new(bytes.Buffer),
+		err:       new(bytes.Buffer),
 	}
+}
+
+func (s *fakeHandler) Event(event TestEvent, execution *Execution) error {
+	line, err := s.formatter(event, execution)
+	s.out.WriteString(line)
+	return err
+}
+
+func (s *fakeHandler) Err(text string) error {
+	s.err.WriteString(text + "\n")
+	return nil
 }
 
 func patchPkgPathPrefix(val string) func() {
@@ -62,12 +71,12 @@ func TestGetPkgPathPrefix(t *testing.T) {
 func TestScanTestOutputWithShortVerboseFormat(t *testing.T) {
 	defer patchPkgPathPrefix("github.com/gotestyourself/gotestyourself")()
 
-	shim := newConfigShim(shortVerboseFormat, "go-test-json")
+	shim := newFakeHandler(shortVerboseFormat, "go-test-json")
 	exec, err := ScanTestOutput(shim.Config(t))
 
 	assert.NilError(t, err)
-	golden.Assert(t, shim.Out.String(), "short-verbose-format.out")
-	golden.Assert(t, shim.Err.String(), "short-verbose-format.err")
+	golden.Assert(t, shim.out.String(), "short-verbose-format.out")
+	golden.Assert(t, shim.err.String(), "short-verbose-format.err")
 	assert.DeepEqual(t, exec, expectedExecution, cmpExecutionShallow)
 }
 
@@ -126,47 +135,47 @@ func stringPath(spec string) func(gocmp.Path) bool {
 func TestScanTestOutputWithDotsFormat(t *testing.T) {
 	defer patchPkgPathPrefix("github.com/gotestyourself/gotestyourself")()
 
-	shim := newConfigShim(dotsFormat, "go-test-json")
+	shim := newFakeHandler(dotsFormat, "go-test-json")
 	exec, err := ScanTestOutput(shim.Config(t))
 
 	assert.NilError(t, err)
-	golden.Assert(t, shim.Out.String(), "dots-format.out")
-	golden.Assert(t, shim.Err.String(), "dots-format.err")
+	golden.Assert(t, shim.out.String(), "dots-format.out")
+	golden.Assert(t, shim.err.String(), "dots-format.err")
 	assert.DeepEqual(t, exec, expectedExecution, cmpExecutionShallow)
 }
 
 func TestScanTestOutputWithShortFormat(t *testing.T) {
 	defer patchPkgPathPrefix("github.com/gotestyourself/gotestyourself")()
 
-	shim := newConfigShim(shortFormat, "go-test-json")
+	shim := newFakeHandler(shortFormat, "go-test-json")
 	exec, err := ScanTestOutput(shim.Config(t))
 
 	assert.NilError(t, err)
-	golden.Assert(t, shim.Out.String(), "short-format.out")
-	golden.Assert(t, shim.Err.String(), "short-format.err")
+	golden.Assert(t, shim.out.String(), "short-format.out")
+	golden.Assert(t, shim.err.String(), "short-format.err")
 	assert.DeepEqual(t, exec, expectedExecution, cmpExecutionShallow)
 }
 
 func TestScanTestOutputWithStandardVerboseFormat(t *testing.T) {
 	defer patchPkgPathPrefix("github.com/gotestyourself/gotestyourself")()
 
-	shim := newConfigShim(standardVerboseFormat, "go-test-json")
+	shim := newFakeHandler(standardVerboseFormat, "go-test-json")
 	exec, err := ScanTestOutput(shim.Config(t))
 
 	assert.NilError(t, err)
-	golden.Assert(t, shim.Out.String(), "go-test-verbose.out")
-	golden.Assert(t, shim.Err.String(), "go-test-verbose.err")
+	golden.Assert(t, shim.out.String(), "go-test-verbose.out")
+	golden.Assert(t, shim.err.String(), "go-test-verbose.err")
 	assert.DeepEqual(t, exec, expectedExecution, cmpExecutionShallow)
 }
 
 func TestScanTestOutputWithStandardQuietFormat(t *testing.T) {
 	defer patchPkgPathPrefix("github.com/gotestyourself/gotestyourself")()
 
-	shim := newConfigShim(standardQuietFormat, "go-test-json")
+	shim := newFakeHandler(standardQuietFormat, "go-test-json")
 	exec, err := ScanTestOutput(shim.Config(t))
 
 	assert.NilError(t, err)
-	golden.Assert(t, shim.Out.String(), "standard-quiet-format.out")
-	golden.Assert(t, shim.Err.String(), "standard-quiet-format.err")
+	golden.Assert(t, shim.out.String(), "standard-quiet-format.out")
+	golden.Assert(t, shim.err.String(), "standard-quiet-format.err")
 	assert.DeepEqual(t, exec, expectedExecution, cmpExecutionShallow)
 }

--- a/testjson/summary.go
+++ b/testjson/summary.go
@@ -16,7 +16,7 @@ func PrintSummary(out io.Writer, execution *Execution) error {
 		formatTestCount(len(execution.Skipped()), "skipped", ""),
 		formatTestCount(len(execution.Failed()), "failure", "s"),
 		formatTestCount(len(errors), "error", "s"),
-		formatDurationAsSeconds(execution.Elapsed(), 3))
+		FormatDurationAsSeconds(execution.Elapsed(), 3))
 
 	writeTestCaseSummary(out, execution, formatSkipped)
 	writeTestCaseSummary(out, execution, formatFailures)
@@ -42,8 +42,9 @@ func formatTestCount(count int, category string, pluralize string) string {
 	return fmt.Sprintf(", %d %s", count, category)
 }
 
-func formatDurationAsSeconds(d time.Duration, precision int) string {
-	return fmt.Sprintf("%.[2]*[1]fs", float64(d.Nanoseconds()/1000000)/1000, precision)
+// FormatDurationAsSeconds formats a time.Duration as a float.
+func FormatDurationAsSeconds(d time.Duration, precision int) string {
+	return fmt.Sprintf("%.[2]*[1]fs", d.Seconds(), precision)
 }
 
 func writeTestCaseSummary(out io.Writer, execution *Execution, conf testCaseFormatConfig) {
@@ -57,7 +58,7 @@ func writeTestCaseSummary(out io.Writer, execution *Execution, conf testCaseForm
 			conf.prefix,
 			relativePackagePath(tc.Package),
 			tc.Test,
-			formatDurationAsSeconds(tc.Elapsed, 2))
+			FormatDurationAsSeconds(tc.Elapsed, 2))
 		for _, line := range execution.Output(tc.Package, tc.Test) {
 			if isRunLine(line) || conf.filter(line) {
 				continue

--- a/testjson/summary_test.go
+++ b/testjson/summary_test.go
@@ -18,8 +18,8 @@ func TestPrintSummaryNoFailures(t *testing.T) {
 	exec := &Execution{
 		started: fake.Now(),
 		packages: map[string]*Package{
-			"foo":   {run: 12},
-			"other": {run: 1},
+			"foo":   {Total: 12},
+			"other": {Total: 1},
 		},
 	}
 	fake.Advance(34123111 * time.Microsecond)
@@ -40,8 +40,8 @@ func TestPrintSummaryWithFailures(t *testing.T) {
 		started: fake.Now(),
 		packages: map[string]*Package{
 			"example.com/project/fs": {
-				run: 12,
-				failed: []TestCase{
+				Total: 12,
+				Failed: []TestCase{
 					{
 						Package: "example.com/project/fs",
 						Test:    "TestFileDo",
@@ -68,15 +68,15 @@ Some stdout/stderr here
 				action: ActionFail,
 			},
 			"example.com/project/pkg/more": {
-				run: 1,
-				failed: []TestCase{
+				Total: 1,
+				Failed: []TestCase{
 					{
 						Package: "example.com/project/pkg/more",
 						Test:    "TestAlbatross",
 						Elapsed: 40 * time.Millisecond,
 					},
 				},
-				skipped: []TestCase{
+				Skipped: []TestCase{
 					{
 						Package: "example.com/project/pkg/more",
 						Test:    "TestOnlySometimes",


### PR DESCRIPTION
Closes #4

Add flags to optionally output a JUnit XML file, or a JSON file with all the TestEvents.