### PR TITLE
Fix vendor, update to new spf13/pflag behaviour

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
                 dep ensure
             docker cp \
                 deps-$CIRCLE_BUILD_NUM:/go/src/gotest.tools/gotestsum/vendor \
-                vendor
+                .
       - run:
           name: "Lint"
           command: |

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -51,8 +51,8 @@
 [[projects]]
   name = "github.com/spf13/pflag"
   packages = ["."]
-  revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
-  version = "v1.0.0"
+  revision = "583c0c0531f06d5278b7d917446061adc344b5cd"
+  version = "v1.0.1"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,3 +1,7 @@
+[prune]
+  non-go = true
+  go-tests = true
+  unused-packages = true
 
 [[constraint]]
   name = "github.com/google/go-cmp"
@@ -14,11 +18,6 @@
 [[constraint]]
   name = "github.com/spf13/pflag"
   version = "1.0.0"
-
-[prune]
-  non-go = true
-  go-tests = true
-  unused-packages = true
 
 [[constraint]]
   name = "github.com/sirupsen/logrus"

--- a/main.go
+++ b/main.go
@@ -18,7 +18,12 @@ import (
 func main() {
 	name := os.Args[0]
 	flags, opts := setupFlags(name)
-	if err := flags.Parse(os.Args[1:]); err != nil {
+	switch err := flags.Parse(os.Args[1:]); {
+	case err == pflag.ErrHelp:
+		os.Exit(0)
+	case err != nil:
+		log.Error(err.Error())
+		flags.Usage()
 		os.Exit(1)
 	}
 	opts.args = flags.Args()
@@ -173,6 +178,10 @@ type proc struct {
 }
 
 func startGoTest(ctx context.Context, args []string) (proc, error) {
+	if len(args) == 0 {
+		return proc{}, errors.New("missing command to run")
+	}
+
 	ctx, cancel := context.WithCancel(ctx)
 	p := proc{
 		cmd:    exec.CommandContext(ctx, args[0], args[1:]...),


### PR DESCRIPTION
I noticed some strange behaviour with `gotestsum` when I used `go get` to download dependencies. When I used unknown flags it was not giving me any error. I guess there is a regression in `spf13/pflag`(see https://github.com/spf13/pflag/issues/176)

Update vendor to pickup the latest changes, and update flag parsing logic to handle the new behaviour.

Also fix a panic with `--raw-command`