### PR TITLE
Add more go module stderr lines to the whitelist

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,14 +4,14 @@ require (
 	github.com/fatih/color v1.6.0
 	github.com/google/go-cmp v0.2.0
 	github.com/jonboulle/clockwork v0.1.0
-	github.com/mattn/go-colorable v0.0.9
-	github.com/mattn/go-isatty v0.0.3
+	github.com/mattn/go-colorable v0.0.9 // indirect
+	github.com/mattn/go-isatty v0.0.3 // indirect
 	github.com/pkg/errors v0.8.0
 	github.com/sirupsen/logrus v1.0.5
 	github.com/spf13/pflag v1.0.1
-	golang.org/x/crypto v0.0.0-20180426230345-b49d69b5da94
-	golang.org/x/net v0.0.0-20181102091132-c10e9556a7bc
+	golang.org/x/crypto v0.0.0-20180426230345-b49d69b5da94 // indirect
+	golang.org/x/net v0.0.0-20181102091132-c10e9556a7bc // indirect
 	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f
-	golang.org/x/sys v0.0.0-20180427151831-cbbc999da32d
+	golang.org/x/sys v0.0.0-20180427151831-cbbc999da32d // indirect
 	gotest.tools v2.1.0+incompatible
 )

--- a/testjson/execution.go
+++ b/testjson/execution.go
@@ -329,8 +329,10 @@ func readStderr(config ScanConfig, execution *Execution) error {
 
 func isGoModuleOutput(scannerText string) bool {
 	prefixes := []string{
-		"go: extracting",
+		"go: copying",
+		"go: creating",
 		"go: downloading",
+		"go: extracting",
 		"go: finding",
 	}
 


### PR DESCRIPTION
These lines are printed when a go command runs for the first time on
go1.11 and a go.mod does not yet exist.