### PR TITLE
Remove s suffix from junitxml times

### DIFF
--- a/internal/junitxml/report.go
+++ b/internal/junitxml/report.go
@@ -4,11 +4,13 @@ package junitxml
 
 import (
 	"encoding/xml"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -74,7 +76,7 @@ func generate(exec *testjson.Execution) JUnitTestSuites {
 		junitpkg := JUnitTestSuite{
 			Name:       pkgname,
 			Tests:      pkg.Total,
-			Time:       testjson.FormatDurationAsSeconds(pkg.Elapsed(), 3),
+			Time:       formatDurationAsSeconds(pkg.Elapsed()),
 			Properties: packageProperties(version),
 			TestCases:  packageTestCases(pkg),
 			Failures:   len(pkg.Failed),
@@ -82,6 +84,10 @@ func generate(exec *testjson.Execution) JUnitTestSuites {
 		suites.Suites = append(suites.Suites, junitpkg)
 	}
 	return suites
+}
+
+func formatDurationAsSeconds(d time.Duration) string {
+	return fmt.Sprintf("%f", d.Seconds())
 }
 
 func packageProperties(goVersion string) []JUnitProperty {
@@ -150,7 +156,7 @@ func newJUnitTestCase(tc testjson.TestCase) JUnitTestCase {
 	return JUnitTestCase{
 		Classname: filepath.Base(tc.Package),
 		Name:      tc.Test,
-		Time:      testjson.FormatDurationAsSeconds(tc.Elapsed, 3),
+		Time:      formatDurationAsSeconds(tc.Elapsed),
 	}
 }
 

--- a/internal/junitxml/testdata/junitxml-report.golden
+++ b/internal/junitxml/testdata/junitxml-report.golden
@@ -1,83 +1,83 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="0" failures="0" time="0.000s" name="github.com/gotestyourself/gotestyourself/testjson/internal/badmain">
+	<testsuite tests="0" failures="0" time="0.000000" name="github.com/gotestyourself/gotestyourself/testjson/internal/badmain">
 		<properties>
 			<property name="go.version" value="go7.7.7"></property>
 		</properties>
-		<testcase classname="." name="TestMain" time="0.000s">
+		<testcase classname="." name="TestMain" time="0.000000">
 			<failure message="Failed" type="">sometimes main can exit 2&#xA;FAIL&#x9;github.com/gotestyourself/gotestyourself/testjson/internal/badmain&#x9;0.010s&#xA;</failure>
 		</testcase>
 	</testsuite>
-	<testsuite tests="18" failures="0" time="0.020s" name="github.com/gotestyourself/gotestyourself/testjson/internal/good">
+	<testsuite tests="18" failures="0" time="0.020000" name="github.com/gotestyourself/gotestyourself/testjson/internal/good">
 		<properties>
 			<property name="go.version" value="go7.7.7"></property>
 		</properties>
-		<testcase classname="good" name="TestSkipped" time="0.000s">
+		<testcase classname="good" name="TestSkipped" time="0.000000">
 			<skipped message="=== RUN   TestSkipped&#xA;--- SKIP: TestSkipped (0.00s)&#xA;&#x9;good_test.go:23: &#xA;"></skipped>
 		</testcase>
-		<testcase classname="good" name="TestSkippedWitLog" time="0.000s">
+		<testcase classname="good" name="TestSkippedWitLog" time="0.000000">
 			<skipped message="=== RUN   TestSkippedWitLog&#xA;--- SKIP: TestSkippedWitLog (0.00s)&#xA;&#x9;good_test.go:27: the skip message&#xA;"></skipped>
 		</testcase>
-		<testcase classname="good" name="TestPassed" time="0.000s"></testcase>
-		<testcase classname="good" name="TestPassedWithLog" time="0.000s"></testcase>
-		<testcase classname="good" name="TestPassedWithStdout" time="0.000s"></testcase>
-		<testcase classname="good" name="TestWithStderr" time="0.000s"></testcase>
-		<testcase classname="good" name="TestNestedSuccess/a/sub" time="0.000s"></testcase>
-		<testcase classname="good" name="TestNestedSuccess/a" time="0.000s"></testcase>
-		<testcase classname="good" name="TestNestedSuccess/b/sub" time="0.000s"></testcase>
-		<testcase classname="good" name="TestNestedSuccess/b" time="0.000s"></testcase>
-		<testcase classname="good" name="TestNestedSuccess/c/sub" time="0.000s"></testcase>
-		<testcase classname="good" name="TestNestedSuccess/c" time="0.000s"></testcase>
-		<testcase classname="good" name="TestNestedSuccess/d/sub" time="0.000s"></testcase>
-		<testcase classname="good" name="TestNestedSuccess/d" time="0.000s"></testcase>
-		<testcase classname="good" name="TestNestedSuccess" time="0.000s"></testcase>
-		<testcase classname="good" name="TestParallelTheThird" time="0.000s"></testcase>
-		<testcase classname="good" name="TestParallelTheSecond" time="0.010s"></testcase>
-		<testcase classname="good" name="TestParallelTheFirst" time="0.010s"></testcase>
+		<testcase classname="good" name="TestPassed" time="0.000000"></testcase>
+		<testcase classname="good" name="TestPassedWithLog" time="0.000000"></testcase>
+		<testcase classname="good" name="TestPassedWithStdout" time="0.000000"></testcase>
+		<testcase classname="good" name="TestWithStderr" time="0.000000"></testcase>
+		<testcase classname="good" name="TestNestedSuccess/a/sub" time="0.000000"></testcase>
+		<testcase classname="good" name="TestNestedSuccess/a" time="0.000000"></testcase>
+		<testcase classname="good" name="TestNestedSuccess/b/sub" time="0.000000"></testcase>
+		<testcase classname="good" name="TestNestedSuccess/b" time="0.000000"></testcase>
+		<testcase classname="good" name="TestNestedSuccess/c/sub" time="0.000000"></testcase>
+		<testcase classname="good" name="TestNestedSuccess/c" time="0.000000"></testcase>
+		<testcase classname="good" name="TestNestedSuccess/d/sub" time="0.000000"></testcase>
+		<testcase classname="good" name="TestNestedSuccess/d" time="0.000000"></testcase>
+		<testcase classname="good" name="TestNestedSuccess" time="0.000000"></testcase>
+		<testcase classname="good" name="TestParallelTheThird" time="0.000000"></testcase>
+		<testcase classname="good" name="TestParallelTheSecond" time="0.010000"></testcase>
+		<testcase classname="good" name="TestParallelTheFirst" time="0.010000"></testcase>
 	</testsuite>
-	<testsuite tests="28" failures="4" time="0.020s" name="github.com/gotestyourself/gotestyourself/testjson/internal/stub">
+	<testsuite tests="28" failures="4" time="0.020000" name="github.com/gotestyourself/gotestyourself/testjson/internal/stub">
 		<properties>
 			<property name="go.version" value="go7.7.7"></property>
 		</properties>
-		<testcase classname="stub" name="TestFailed" time="0.000s">
+		<testcase classname="stub" name="TestFailed" time="0.000000">
 			<failure message="Failed" type="">=== RUN   TestFailed&#xA;--- FAIL: TestFailed (0.00s)&#xA;&#x9;stub_test.go:34: this failed&#xA;</failure>
 		</testcase>
-		<testcase classname="stub" name="TestFailedWithStderr" time="0.000s">
+		<testcase classname="stub" name="TestFailedWithStderr" time="0.000000">
 			<failure message="Failed" type="">=== RUN   TestFailedWithStderr&#xA;this is stderr&#xA;--- FAIL: TestFailedWithStderr (0.00s)&#xA;&#x9;stub_test.go:43: also failed&#xA;</failure>
 		</testcase>
-		<testcase classname="stub" name="TestNestedWithFailure/c" time="0.000s">
+		<testcase classname="stub" name="TestNestedWithFailure/c" time="0.000000">
 			<failure message="Failed" type="">=== RUN   TestNestedWithFailure/c&#xA;    --- FAIL: TestNestedWithFailure/c (0.00s)&#xA;    &#x9;stub_test.go:65: failed&#xA;</failure>
 		</testcase>
-		<testcase classname="stub" name="TestNestedWithFailure" time="0.000s">
+		<testcase classname="stub" name="TestNestedWithFailure" time="0.000000">
 			<failure message="Failed" type="">=== RUN   TestNestedWithFailure&#xA;--- FAIL: TestNestedWithFailure (0.00s)&#xA;</failure>
 		</testcase>
-		<testcase classname="stub" name="TestSkipped" time="0.000s">
+		<testcase classname="stub" name="TestSkipped" time="0.000000">
 			<skipped message="=== RUN   TestSkipped&#xA;--- SKIP: TestSkipped (0.00s)&#xA;&#x9;stub_test.go:26: &#xA;"></skipped>
 		</testcase>
-		<testcase classname="stub" name="TestSkippedWitLog" time="0.000s">
+		<testcase classname="stub" name="TestSkippedWitLog" time="0.000000">
 			<skipped message="=== RUN   TestSkippedWitLog&#xA;--- SKIP: TestSkippedWitLog (0.00s)&#xA;&#x9;stub_test.go:30: the skip message&#xA;"></skipped>
 		</testcase>
-		<testcase classname="stub" name="TestPassed" time="0.000s"></testcase>
-		<testcase classname="stub" name="TestPassedWithLog" time="0.000s"></testcase>
-		<testcase classname="stub" name="TestPassedWithStdout" time="0.000s"></testcase>
-		<testcase classname="stub" name="TestWithStderr" time="0.000s"></testcase>
-		<testcase classname="stub" name="TestNestedWithFailure/a/sub" time="0.000s"></testcase>
-		<testcase classname="stub" name="TestNestedWithFailure/a" time="0.000s"></testcase>
-		<testcase classname="stub" name="TestNestedWithFailure/b/sub" time="0.000s"></testcase>
-		<testcase classname="stub" name="TestNestedWithFailure/b" time="0.000s"></testcase>
-		<testcase classname="stub" name="TestNestedWithFailure/d/sub" time="0.000s"></testcase>
-		<testcase classname="stub" name="TestNestedWithFailure/d" time="0.000s"></testcase>
-		<testcase classname="stub" name="TestNestedSuccess/a/sub" time="0.000s"></testcase>
-		<testcase classname="stub" name="TestNestedSuccess/a" time="0.000s"></testcase>
-		<testcase classname="stub" name="TestNestedSuccess/b/sub" time="0.000s"></testcase>
-		<testcase classname="stub" name="TestNestedSuccess/b" time="0.000s"></testcase>
-		<testcase classname="stub" name="TestNestedSuccess/c/sub" time="0.000s"></testcase>
-		<testcase classname="stub" name="TestNestedSuccess/c" time="0.000s"></testcase>
-		<testcase classname="stub" name="TestNestedSuccess/d/sub" time="0.000s"></testcase>
-		<testcase classname="stub" name="TestNestedSuccess/d" time="0.000s"></testcase>
-		<testcase classname="stub" name="TestNestedSuccess" time="0.000s"></testcase>
-		<testcase classname="stub" name="TestParallelTheThird" time="0.000s"></testcase>
-		<testcase classname="stub" name="TestParallelTheSecond" time="0.010s"></testcase>
-		<testcase classname="stub" name="TestParallelTheFirst" time="0.010s"></testcase>
+		<testcase classname="stub" name="TestPassed" time="0.000000"></testcase>
+		<testcase classname="stub" name="TestPassedWithLog" time="0.000000"></testcase>
+		<testcase classname="stub" name="TestPassedWithStdout" time="0.000000"></testcase>
+		<testcase classname="stub" name="TestWithStderr" time="0.000000"></testcase>
+		<testcase classname="stub" name="TestNestedWithFailure/a/sub" time="0.000000"></testcase>
+		<testcase classname="stub" name="TestNestedWithFailure/a" time="0.000000"></testcase>
+		<testcase classname="stub" name="TestNestedWithFailure/b/sub" time="0.000000"></testcase>
+		<testcase classname="stub" name="TestNestedWithFailure/b" time="0.000000"></testcase>
+		<testcase classname="stub" name="TestNestedWithFailure/d/sub" time="0.000000"></testcase>
+		<testcase classname="stub" name="TestNestedWithFailure/d" time="0.000000"></testcase>
+		<testcase classname="stub" name="TestNestedSuccess/a/sub" time="0.000000"></testcase>
+		<testcase classname="stub" name="TestNestedSuccess/a" time="0.000000"></testcase>
+		<testcase classname="stub" name="TestNestedSuccess/b/sub" time="0.000000"></testcase>
+		<testcase classname="stub" name="TestNestedSuccess/b" time="0.000000"></testcase>
+		<testcase classname="stub" name="TestNestedSuccess/c/sub" time="0.000000"></testcase>
+		<testcase classname="stub" name="TestNestedSuccess/c" time="0.000000"></testcase>
+		<testcase classname="stub" name="TestNestedSuccess/d/sub" time="0.000000"></testcase>
+		<testcase classname="stub" name="TestNestedSuccess/d" time="0.000000"></testcase>
+		<testcase classname="stub" name="TestNestedSuccess" time="0.000000"></testcase>
+		<testcase classname="stub" name="TestParallelTheThird" time="0.000000"></testcase>
+		<testcase classname="stub" name="TestParallelTheSecond" time="0.010000"></testcase>
+		<testcase classname="stub" name="TestParallelTheFirst" time="0.010000"></testcase>
 	</testsuite>
 </testsuites>

--- a/testjson/summary.go
+++ b/testjson/summary.go
@@ -103,7 +103,7 @@ func formatTestCount(count int, category string, pluralize string) string {
 	return fmt.Sprintf(", %d %s", count, category)
 }
 
-// FormatDurationAsSeconds formats a time.Duration as a float.
+// FormatDurationAsSeconds formats a time.Duration as a float with an s suffix.
 func FormatDurationAsSeconds(d time.Duration, precision int) string {
 	return fmt.Sprintf("%.[2]*[1]fs", d.Seconds(), precision)
 }


### PR DESCRIPTION
It appears that `time` is generally just a `double` and does not have a unit suffix.