### PR TITLE
Add a --no-cache option for avoiding cached test results

### DIFF
--- a/main.go
+++ b/main.go
@@ -73,6 +73,7 @@ Formats:
 	flags.StringVar(&opts.junitFile, "junitfile",
 		lookEnvWithDefault("GOTESTSUM_JUNITFILE", ""),
 		"write a JUnit XML file")
+	flags.BoolVar(&opts.noCache, "no-cache", false, "disable test caching")
 	flags.BoolVar(&opts.noColor, "no-color", false, "disable color output")
 	flags.Var(opts.noSummary, "no-summary",
 		fmt.Sprintf("do not print summary of: %s", testjson.SummarizeAll.String()))
@@ -94,6 +95,7 @@ type options struct {
 	jsonFile   string
 	junitFile  string
 	noColor    bool
+	noCache    bool
 	noSummary  *noSummaryValue
 }
 
@@ -153,6 +155,9 @@ func goTestCmdArgs(opts *options) []string {
 	}
 	if testPath := pathFromEnv(""); testPath != "" {
 		args = append(args, testPath)
+	}
+	if opts.noCache {
+		args = append(args, "-count=1")
 	}
 	return append(defaultArgs, args...)
 }


### PR DESCRIPTION
At the minute there doesn't seem to be a way to avoid the underlying behaviour of `go test` caching test results if nothing has changed. 

This behaviour was introduced in [Go 1.10](https://golang.org/doc/go1.10#test): "The go test command now caches test results"

Apparently "The idiomatic way to bypass test caching is to use -count=1".

This PR adds `--no-cache` which sets `--count=1`. IMO it's clearer, but we could also just expose `--count`. 

Btw thanks for the great tool!



