### PR TITLE
Identify and, filter or display coverage output

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -57,3 +57,4 @@ gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gotest.tools v2.1.0+incompatible h1:5USw7CrJBYKqjg9R7QlA6jzqZKEAtvW82aNmsxxGPxw=
 gotest.tools v2.1.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=

--- a/go.sum
+++ b/go.sum
@@ -57,4 +57,3 @@ gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gotest.tools v2.1.0+incompatible h1:5USw7CrJBYKqjg9R7QlA6jzqZKEAtvW82aNmsxxGPxw=
 gotest.tools v2.1.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
-gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=

--- a/testjson/execution.go
+++ b/testjson/execution.go
@@ -134,18 +134,25 @@ func (e *Execution) add(event TestEvent) {
 		e.packages[event.Package] = pkg
 	}
 	if event.PackageEvent() {
-		switch event.Action {
-		case ActionPass, ActionFail:
-			pkg.action = event.Action
-		case ActionOutput:
-			if isCoverageOutput(event.Output) {
-				pkg.coverage = strings.TrimRight(event.Output, "\n")
-			}
-			pkg.output[""] = append(pkg.output[""], event.Output)
-		}
+		e.addPackageEvent(pkg, event)
 		return
 	}
+	e.addTestEvent(pkg, event)
+}
 
+func (e *Execution) addPackageEvent(pkg *Package, event TestEvent) {
+	switch event.Action {
+	case ActionPass, ActionFail:
+		pkg.action = event.Action
+	case ActionOutput:
+		if isCoverageOutput(event.Output) {
+			pkg.coverage = strings.TrimRight(event.Output, "\n")
+		}
+		pkg.output[""] = append(pkg.output[""], event.Output)
+	}
+}
+
+func (e *Execution) addTestEvent(pkg *Package, event TestEvent) {
 	switch event.Action {
 	case ActionRun:
 		pkg.Total++

--- a/testjson/execution_test.go
+++ b/testjson/execution_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"gotest.tools/assert"
 )
 
@@ -22,3 +23,23 @@ func TestPackage_Elapsed(t *testing.T) {
 	}
 	assert.Equal(t, pkg.Elapsed(), 3100*time.Millisecond)
 }
+
+func TestExecution_Add_PackageCoverage(t *testing.T) {
+	exec := NewExecution()
+	exec.add(TestEvent{
+		Package: "mytestpkg",
+		Action:  ActionOutput,
+		Output:  "coverage: 33.1% of statements\n",
+	})
+
+	pkg := exec.Package("mytestpkg")
+	expected := &Package{
+		coverage: "coverage: 33.1% of statements",
+		output: map[string][]string{
+			"": {"coverage: 33.1% of statements\n"},
+		},
+	}
+	assert.DeepEqual(t, pkg, expected, cmpPackage)
+}
+
+var cmpPackage = cmp.AllowUnexported(Package{})

--- a/testjson/generate.sh
+++ b/testjson/generate.sh
@@ -26,3 +26,9 @@ go test -p 1 -json -tags 'stubpkg panic' ./internal/... \
     > testdata/go-test-json-with-panic.out \
     2> testdata/go-test-json-with-panic.err \
     | true
+
+
+go test -p 1 -json -tags stubpkg -cover ./internal/... \
+    > testdata/go-test-json-with-cover.out \
+    2> testdata/go-test-json-with-cover.err \
+    | true

--- a/testjson/testdata/go-test-json-with-cover.err
+++ b/testjson/testdata/go-test-json-with-cover.err
@@ -1,0 +1,2 @@
+# gotest.tools/gotestsum/testjson/internal/broken
+internal/broken/broken.go:5:21: undefined: somepackage

--- a/testjson/testdata/go-test-json-with-cover.out
+++ b/testjson/testdata/go-test-json-with-cover.out
@@ -1,0 +1,233 @@
+{"Time":"2019-06-26T19:28:47.238149257-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/badmain","Output":"sometimes main can exit 2\n"}
+{"Time":"2019-06-26T19:28:47.238279925-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/badmain","Output":"FAIL\tgotest.tools/gotestsum/testjson/internal/badmain\t0.001s\n"}
+{"Time":"2019-06-26T19:28:47.238295101-04:00","Action":"fail","Package":"gotest.tools/gotestsum/testjson/internal/badmain","Elapsed":0.001}
+{"Time":"2019-06-26T19:28:47.458747463-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestPassed"}
+{"Time":"2019-06-26T19:28:47.458782622-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestPassed","Output":"=== RUN   TestPassed\n"}
+{"Time":"2019-06-26T19:28:47.458799449-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestPassed","Output":"--- PASS: TestPassed (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.458806961-04:00","Action":"pass","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestPassed","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.458813231-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestPassedWithLog"}
+{"Time":"2019-06-26T19:28:47.458817456-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestPassedWithLog","Output":"=== RUN   TestPassedWithLog\n"}
+{"Time":"2019-06-26T19:28:47.458823547-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestPassedWithLog","Output":"--- PASS: TestPassedWithLog (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.458829353-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestPassedWithLog","Output":"    good_test.go:15: this is a log\n"}
+{"Time":"2019-06-26T19:28:47.458833761-04:00","Action":"pass","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestPassedWithLog","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.458837672-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestPassedWithStdout"}
+{"Time":"2019-06-26T19:28:47.458841435-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestPassedWithStdout","Output":"=== RUN   TestPassedWithStdout\n"}
+{"Time":"2019-06-26T19:28:47.458845644-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestPassedWithStdout","Output":"this is a Print\n"}
+{"Time":"2019-06-26T19:28:47.458850344-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestPassedWithStdout","Output":"--- PASS: TestPassedWithStdout (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.458855053-04:00","Action":"pass","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestPassedWithStdout","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.458858851-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestSkipped"}
+{"Time":"2019-06-26T19:28:47.458862526-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestSkipped","Output":"=== RUN   TestSkipped\n"}
+{"Time":"2019-06-26T19:28:47.458870529-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestSkipped","Output":"--- SKIP: TestSkipped (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.458876671-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestSkipped","Output":"    good_test.go:23: \n"}
+{"Time":"2019-06-26T19:28:47.45888138-04:00","Action":"skip","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestSkipped","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.458885294-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestSkippedWitLog"}
+{"Time":"2019-06-26T19:28:47.458889-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestSkippedWitLog","Output":"=== RUN   TestSkippedWitLog\n"}
+{"Time":"2019-06-26T19:28:47.458900865-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestSkippedWitLog","Output":"--- SKIP: TestSkippedWitLog (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.458906593-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestSkippedWitLog","Output":"    good_test.go:27: the skip message\n"}
+{"Time":"2019-06-26T19:28:47.458914409-04:00","Action":"skip","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestSkippedWitLog","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.45892158-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestWithStderr"}
+{"Time":"2019-06-26T19:28:47.458927969-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestWithStderr","Output":"=== RUN   TestWithStderr\n"}
+{"Time":"2019-06-26T19:28:47.458932512-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestWithStderr","Output":"this is stderr\n"}
+{"Time":"2019-06-26T19:28:47.458937403-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestWithStderr","Output":"--- PASS: TestWithStderr (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.458941827-04:00","Action":"pass","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestWithStderr","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.45894569-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestParallelTheFirst"}
+{"Time":"2019-06-26T19:28:47.458949397-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestParallelTheFirst","Output":"=== RUN   TestParallelTheFirst\n"}
+{"Time":"2019-06-26T19:28:47.458955255-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestParallelTheFirst","Output":"=== PAUSE TestParallelTheFirst\n"}
+{"Time":"2019-06-26T19:28:47.458959476-04:00","Action":"pause","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestParallelTheFirst"}
+{"Time":"2019-06-26T19:28:47.458963459-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestParallelTheSecond"}
+{"Time":"2019-06-26T19:28:47.458967038-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestParallelTheSecond","Output":"=== RUN   TestParallelTheSecond\n"}
+{"Time":"2019-06-26T19:28:47.458971275-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestParallelTheSecond","Output":"=== PAUSE TestParallelTheSecond\n"}
+{"Time":"2019-06-26T19:28:47.458976317-04:00","Action":"pause","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestParallelTheSecond"}
+{"Time":"2019-06-26T19:28:47.458983631-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestParallelTheThird"}
+{"Time":"2019-06-26T19:28:47.458990606-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestParallelTheThird","Output":"=== RUN   TestParallelTheThird\n"}
+{"Time":"2019-06-26T19:28:47.459003982-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestParallelTheThird","Output":"=== PAUSE TestParallelTheThird\n"}
+{"Time":"2019-06-26T19:28:47.459011662-04:00","Action":"pause","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestParallelTheThird"}
+{"Time":"2019-06-26T19:28:47.459019071-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestNestedSuccess"}
+{"Time":"2019-06-26T19:28:47.459025415-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestNestedSuccess","Output":"=== RUN   TestNestedSuccess\n"}
+{"Time":"2019-06-26T19:28:47.459032888-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestNestedSuccess/a"}
+{"Time":"2019-06-26T19:28:47.45903963-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestNestedSuccess/a","Output":"=== RUN   TestNestedSuccess/a\n"}
+{"Time":"2019-06-26T19:28:47.459053477-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestNestedSuccess/a/sub"}
+{"Time":"2019-06-26T19:28:47.459061016-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestNestedSuccess/a/sub","Output":"=== RUN   TestNestedSuccess/a/sub\n"}
+{"Time":"2019-06-26T19:28:47.459068324-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestNestedSuccess/b"}
+{"Time":"2019-06-26T19:28:47.459074849-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestNestedSuccess/b","Output":"=== RUN   TestNestedSuccess/b\n"}
+{"Time":"2019-06-26T19:28:47.459082791-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestNestedSuccess/b/sub"}
+{"Time":"2019-06-26T19:28:47.459089945-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestNestedSuccess/b/sub","Output":"=== RUN   TestNestedSuccess/b/sub\n"}
+{"Time":"2019-06-26T19:28:47.459097795-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestNestedSuccess/c"}
+{"Time":"2019-06-26T19:28:47.459105018-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestNestedSuccess/c","Output":"=== RUN   TestNestedSuccess/c\n"}
+{"Time":"2019-06-26T19:28:47.459110103-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestNestedSuccess/c/sub"}
+{"Time":"2019-06-26T19:28:47.459113836-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestNestedSuccess/c/sub","Output":"=== RUN   TestNestedSuccess/c/sub\n"}
+{"Time":"2019-06-26T19:28:47.459123681-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestNestedSuccess/d"}
+{"Time":"2019-06-26T19:28:47.459129671-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestNestedSuccess/d","Output":"=== RUN   TestNestedSuccess/d\n"}
+{"Time":"2019-06-26T19:28:47.459134441-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestNestedSuccess/d/sub"}
+{"Time":"2019-06-26T19:28:47.459138104-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestNestedSuccess/d/sub","Output":"=== RUN   TestNestedSuccess/d/sub\n"}
+{"Time":"2019-06-26T19:28:47.459144627-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestNestedSuccess","Output":"--- PASS: TestNestedSuccess (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.459151692-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestNestedSuccess/a","Output":"    --- PASS: TestNestedSuccess/a (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.459161703-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestNestedSuccess/a/sub","Output":"        --- PASS: TestNestedSuccess/a/sub (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.459169885-04:00","Action":"pass","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestNestedSuccess/a/sub","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.45917454-04:00","Action":"pass","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestNestedSuccess/a","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.459180719-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestNestedSuccess/b","Output":"    --- PASS: TestNestedSuccess/b (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.459185674-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestNestedSuccess/b/sub","Output":"        --- PASS: TestNestedSuccess/b/sub (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.459190244-04:00","Action":"pass","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestNestedSuccess/b/sub","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.459197899-04:00","Action":"pass","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestNestedSuccess/b","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.459203616-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestNestedSuccess/c","Output":"    --- PASS: TestNestedSuccess/c (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.459208678-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestNestedSuccess/c/sub","Output":"        --- PASS: TestNestedSuccess/c/sub (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.459213207-04:00","Action":"pass","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestNestedSuccess/c/sub","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.459217065-04:00","Action":"pass","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestNestedSuccess/c","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.459223713-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestNestedSuccess/d","Output":"    --- PASS: TestNestedSuccess/d (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.459232135-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestNestedSuccess/d/sub","Output":"        --- PASS: TestNestedSuccess/d/sub (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.459240595-04:00","Action":"pass","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestNestedSuccess/d/sub","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.459247791-04:00","Action":"pass","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestNestedSuccess/d","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.459252463-04:00","Action":"pass","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestNestedSuccess","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.459258769-04:00","Action":"cont","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestParallelTheFirst"}
+{"Time":"2019-06-26T19:28:47.459262909-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestParallelTheFirst","Output":"=== CONT  TestParallelTheFirst\n"}
+{"Time":"2019-06-26T19:28:47.459267293-04:00","Action":"cont","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestParallelTheThird"}
+{"Time":"2019-06-26T19:28:47.459271273-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestParallelTheThird","Output":"=== CONT  TestParallelTheThird\n"}
+{"Time":"2019-06-26T19:28:47.459275497-04:00","Action":"cont","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestParallelTheSecond"}
+{"Time":"2019-06-26T19:28:47.459279162-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestParallelTheSecond","Output":"=== CONT  TestParallelTheSecond\n"}
+{"Time":"2019-06-26T19:28:47.46114001-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestParallelTheThird","Output":"--- PASS: TestParallelTheThird (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.46514413-04:00","Action":"pass","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestParallelTheThird","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.465163676-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestParallelTheSecond","Output":"--- PASS: TestParallelTheSecond (0.01s)\n"}
+{"Time":"2019-06-26T19:28:47.469149033-04:00","Action":"pass","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestParallelTheSecond","Elapsed":0.01}
+{"Time":"2019-06-26T19:28:47.469167786-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestParallelTheFirst","Output":"--- PASS: TestParallelTheFirst (0.01s)\n"}
+{"Time":"2019-06-26T19:28:47.469179349-04:00","Action":"pass","Package":"gotest.tools/gotestsum/testjson/internal/good","Test":"TestParallelTheFirst","Elapsed":0.01}
+{"Time":"2019-06-26T19:28:47.46918812-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Output":"PASS\n"}
+{"Time":"2019-06-26T19:28:47.469212191-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Output":"coverage: 0.0% of statements\n"}
+{"Time":"2019-06-26T19:28:47.469354607-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/good","Output":"ok  \tgotest.tools/gotestsum/testjson/internal/good\t0.011s\tcoverage: 0.0% of statements\n"}
+{"Time":"2019-06-26T19:28:47.469649009-04:00","Action":"pass","Package":"gotest.tools/gotestsum/testjson/internal/good","Elapsed":0.012}
+{"Time":"2019-06-26T19:28:47.613455232-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestPassed"}
+{"Time":"2019-06-26T19:28:47.613489941-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestPassed","Output":"=== RUN   TestPassed\n"}
+{"Time":"2019-06-26T19:28:47.613501844-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestPassed","Output":"--- PASS: TestPassed (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.613511031-04:00","Action":"pass","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestPassed","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.613518853-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestPassedWithLog"}
+{"Time":"2019-06-26T19:28:47.61352445-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestPassedWithLog","Output":"=== RUN   TestPassedWithLog\n"}
+{"Time":"2019-06-26T19:28:47.613530776-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestPassedWithLog","Output":"--- PASS: TestPassedWithLog (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.613538567-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestPassedWithLog","Output":"    stub_test.go:18: this is a log\n"}
+{"Time":"2019-06-26T19:28:47.61354478-04:00","Action":"pass","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestPassedWithLog","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.613548354-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestPassedWithStdout"}
+{"Time":"2019-06-26T19:28:47.613551518-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestPassedWithStdout","Output":"=== RUN   TestPassedWithStdout\n"}
+{"Time":"2019-06-26T19:28:47.613559269-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestPassedWithStdout","Output":"this is a Print\n"}
+{"Time":"2019-06-26T19:28:47.613566884-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestPassedWithStdout","Output":"--- PASS: TestPassedWithStdout (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.613573134-04:00","Action":"pass","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestPassedWithStdout","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.613578456-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestSkipped"}
+{"Time":"2019-06-26T19:28:47.613584276-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestSkipped","Output":"=== RUN   TestSkipped\n"}
+{"Time":"2019-06-26T19:28:47.613591296-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestSkipped","Output":"--- SKIP: TestSkipped (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.613598946-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestSkipped","Output":"    stub_test.go:26: \n"}
+{"Time":"2019-06-26T19:28:47.613605417-04:00","Action":"skip","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestSkipped","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.613611099-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestSkippedWitLog"}
+{"Time":"2019-06-26T19:28:47.613616389-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestSkippedWitLog","Output":"=== RUN   TestSkippedWitLog\n"}
+{"Time":"2019-06-26T19:28:47.613630786-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestSkippedWitLog","Output":"--- SKIP: TestSkippedWitLog (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.613638067-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestSkippedWitLog","Output":"    stub_test.go:30: the skip message\n"}
+{"Time":"2019-06-26T19:28:47.613644539-04:00","Action":"skip","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestSkippedWitLog","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.613650915-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestFailed"}
+{"Time":"2019-06-26T19:28:47.613656057-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestFailed","Output":"=== RUN   TestFailed\n"}
+{"Time":"2019-06-26T19:28:47.613660804-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestFailed","Output":"--- FAIL: TestFailed (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.613666458-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestFailed","Output":"    stub_test.go:34: this failed\n"}
+{"Time":"2019-06-26T19:28:47.61367398-04:00","Action":"fail","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestFailed","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.613677924-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestWithStderr"}
+{"Time":"2019-06-26T19:28:47.613680917-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestWithStderr","Output":"=== RUN   TestWithStderr\n"}
+{"Time":"2019-06-26T19:28:47.613684329-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestWithStderr","Output":"this is stderr\n"}
+{"Time":"2019-06-26T19:28:47.613689561-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestWithStderr","Output":"--- PASS: TestWithStderr (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.613698172-04:00","Action":"pass","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestWithStderr","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.613701738-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestFailedWithStderr"}
+{"Time":"2019-06-26T19:28:47.613704935-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestFailedWithStderr","Output":"=== RUN   TestFailedWithStderr\n"}
+{"Time":"2019-06-26T19:28:47.613708452-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestFailedWithStderr","Output":"this is stderr\n"}
+{"Time":"2019-06-26T19:28:47.613712122-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestFailedWithStderr","Output":"--- FAIL: TestFailedWithStderr (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.61371559-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestFailedWithStderr","Output":"    stub_test.go:43: also failed\n"}
+{"Time":"2019-06-26T19:28:47.613719048-04:00","Action":"fail","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestFailedWithStderr","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.613722888-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestParallelTheFirst"}
+{"Time":"2019-06-26T19:28:47.613728376-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestParallelTheFirst","Output":"=== RUN   TestParallelTheFirst\n"}
+{"Time":"2019-06-26T19:28:47.613733754-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestParallelTheFirst","Output":"=== PAUSE TestParallelTheFirst\n"}
+{"Time":"2019-06-26T19:28:47.613737105-04:00","Action":"pause","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestParallelTheFirst"}
+{"Time":"2019-06-26T19:28:47.613743446-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestParallelTheSecond"}
+{"Time":"2019-06-26T19:28:47.613746934-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestParallelTheSecond","Output":"=== RUN   TestParallelTheSecond\n"}
+{"Time":"2019-06-26T19:28:47.613750637-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestParallelTheSecond","Output":"=== PAUSE TestParallelTheSecond\n"}
+{"Time":"2019-06-26T19:28:47.613776438-04:00","Action":"pause","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestParallelTheSecond"}
+{"Time":"2019-06-26T19:28:47.613781739-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestParallelTheThird"}
+{"Time":"2019-06-26T19:28:47.613785885-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestParallelTheThird","Output":"=== RUN   TestParallelTheThird\n"}
+{"Time":"2019-06-26T19:28:47.613790704-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestParallelTheThird","Output":"=== PAUSE TestParallelTheThird\n"}
+{"Time":"2019-06-26T19:28:47.613794776-04:00","Action":"pause","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestParallelTheThird"}
+{"Time":"2019-06-26T19:28:47.61379922-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedWithFailure"}
+{"Time":"2019-06-26T19:28:47.613803368-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedWithFailure","Output":"=== RUN   TestNestedWithFailure\n"}
+{"Time":"2019-06-26T19:28:47.613807955-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedWithFailure/a"}
+{"Time":"2019-06-26T19:28:47.613812031-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedWithFailure/a","Output":"=== RUN   TestNestedWithFailure/a\n"}
+{"Time":"2019-06-26T19:28:47.61381662-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedWithFailure/a/sub"}
+{"Time":"2019-06-26T19:28:47.613820714-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedWithFailure/a/sub","Output":"=== RUN   TestNestedWithFailure/a/sub\n"}
+{"Time":"2019-06-26T19:28:47.61382569-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedWithFailure/b"}
+{"Time":"2019-06-26T19:28:47.61382997-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedWithFailure/b","Output":"=== RUN   TestNestedWithFailure/b\n"}
+{"Time":"2019-06-26T19:28:47.613834604-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedWithFailure/b/sub"}
+{"Time":"2019-06-26T19:28:47.613838711-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedWithFailure/b/sub","Output":"=== RUN   TestNestedWithFailure/b/sub\n"}
+{"Time":"2019-06-26T19:28:47.61384326-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedWithFailure/c"}
+{"Time":"2019-06-26T19:28:47.613847279-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedWithFailure/c","Output":"=== RUN   TestNestedWithFailure/c\n"}
+{"Time":"2019-06-26T19:28:47.613851721-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedWithFailure/d"}
+{"Time":"2019-06-26T19:28:47.613856183-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedWithFailure/d","Output":"=== RUN   TestNestedWithFailure/d\n"}
+{"Time":"2019-06-26T19:28:47.613860835-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedWithFailure/d/sub"}
+{"Time":"2019-06-26T19:28:47.613868445-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedWithFailure/d/sub","Output":"=== RUN   TestNestedWithFailure/d/sub\n"}
+{"Time":"2019-06-26T19:28:47.613874256-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedWithFailure","Output":"--- FAIL: TestNestedWithFailure (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.61387999-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedWithFailure/a","Output":"    --- PASS: TestNestedWithFailure/a (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.61388535-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedWithFailure/a/sub","Output":"        --- PASS: TestNestedWithFailure/a/sub (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.613892244-04:00","Action":"pass","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedWithFailure/a/sub","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.61389948-04:00","Action":"pass","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedWithFailure/a","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.613904207-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedWithFailure/b","Output":"    --- PASS: TestNestedWithFailure/b (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.613909201-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedWithFailure/b/sub","Output":"        --- PASS: TestNestedWithFailure/b/sub (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.613914432-04:00","Action":"pass","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedWithFailure/b/sub","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.613918715-04:00","Action":"pass","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedWithFailure/b","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.613923018-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedWithFailure/c","Output":"    --- FAIL: TestNestedWithFailure/c (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.61392748-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedWithFailure/c","Output":"        stub_test.go:65: failed\n"}
+{"Time":"2019-06-26T19:28:47.613932152-04:00","Action":"fail","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedWithFailure/c","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.613936537-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedWithFailure/d","Output":"    --- PASS: TestNestedWithFailure/d (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.613941691-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedWithFailure/d/sub","Output":"        --- PASS: TestNestedWithFailure/d/sub (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.613946328-04:00","Action":"pass","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedWithFailure/d/sub","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.613950391-04:00","Action":"pass","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedWithFailure/d","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.61395449-04:00","Action":"fail","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedWithFailure","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.61395872-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedSuccess"}
+{"Time":"2019-06-26T19:28:47.613962881-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedSuccess","Output":"=== RUN   TestNestedSuccess\n"}
+{"Time":"2019-06-26T19:28:47.613967468-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedSuccess/a"}
+{"Time":"2019-06-26T19:28:47.613971517-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedSuccess/a","Output":"=== RUN   TestNestedSuccess/a\n"}
+{"Time":"2019-06-26T19:28:47.613978979-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedSuccess/a/sub"}
+{"Time":"2019-06-26T19:28:47.613984807-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedSuccess/a/sub","Output":"=== RUN   TestNestedSuccess/a/sub\n"}
+{"Time":"2019-06-26T19:28:47.613989747-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedSuccess/b"}
+{"Time":"2019-06-26T19:28:47.613994192-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedSuccess/b","Output":"=== RUN   TestNestedSuccess/b\n"}
+{"Time":"2019-06-26T19:28:47.613998627-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedSuccess/b/sub"}
+{"Time":"2019-06-26T19:28:47.614002677-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedSuccess/b/sub","Output":"=== RUN   TestNestedSuccess/b/sub\n"}
+{"Time":"2019-06-26T19:28:47.614007557-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedSuccess/c"}
+{"Time":"2019-06-26T19:28:47.614011782-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedSuccess/c","Output":"=== RUN   TestNestedSuccess/c\n"}
+{"Time":"2019-06-26T19:28:47.614016469-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedSuccess/c/sub"}
+{"Time":"2019-06-26T19:28:47.614020531-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedSuccess/c/sub","Output":"=== RUN   TestNestedSuccess/c/sub\n"}
+{"Time":"2019-06-26T19:28:47.614025042-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedSuccess/d"}
+{"Time":"2019-06-26T19:28:47.614029111-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedSuccess/d","Output":"=== RUN   TestNestedSuccess/d\n"}
+{"Time":"2019-06-26T19:28:47.614033552-04:00","Action":"run","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedSuccess/d/sub"}
+{"Time":"2019-06-26T19:28:47.614038027-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedSuccess/d/sub","Output":"=== RUN   TestNestedSuccess/d/sub\n"}
+{"Time":"2019-06-26T19:28:47.614047195-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedSuccess","Output":"--- PASS: TestNestedSuccess (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.614052718-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedSuccess/a","Output":"    --- PASS: TestNestedSuccess/a (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.614059105-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedSuccess/a/sub","Output":"        --- PASS: TestNestedSuccess/a/sub (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.614064422-04:00","Action":"pass","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedSuccess/a/sub","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.614068694-04:00","Action":"pass","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedSuccess/a","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.614072803-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedSuccess/b","Output":"    --- PASS: TestNestedSuccess/b (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.614077732-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedSuccess/b/sub","Output":"        --- PASS: TestNestedSuccess/b/sub (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.614082472-04:00","Action":"pass","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedSuccess/b/sub","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.614090817-04:00","Action":"pass","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedSuccess/b","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.614095867-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedSuccess/c","Output":"    --- PASS: TestNestedSuccess/c (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.61410088-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedSuccess/c/sub","Output":"        --- PASS: TestNestedSuccess/c/sub (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.614105594-04:00","Action":"pass","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedSuccess/c/sub","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.614109835-04:00","Action":"pass","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedSuccess/c","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.614114046-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedSuccess/d","Output":"    --- PASS: TestNestedSuccess/d (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.614118785-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedSuccess/d/sub","Output":"        --- PASS: TestNestedSuccess/d/sub (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.614123463-04:00","Action":"pass","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedSuccess/d/sub","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.614127465-04:00","Action":"pass","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedSuccess/d","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.614131655-04:00","Action":"pass","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestNestedSuccess","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.614135791-04:00","Action":"cont","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestParallelTheFirst"}
+{"Time":"2019-06-26T19:28:47.614139853-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestParallelTheFirst","Output":"=== CONT  TestParallelTheFirst\n"}
+{"Time":"2019-06-26T19:28:47.614144429-04:00","Action":"cont","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestParallelTheThird"}
+{"Time":"2019-06-26T19:28:47.614148541-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestParallelTheThird","Output":"=== CONT  TestParallelTheThird\n"}
+{"Time":"2019-06-26T19:28:47.614154363-04:00","Action":"cont","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestParallelTheSecond"}
+{"Time":"2019-06-26T19:28:47.614158811-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestParallelTheSecond","Output":"=== CONT  TestParallelTheSecond\n"}
+{"Time":"2019-06-26T19:28:47.61583309-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestParallelTheThird","Output":"--- PASS: TestParallelTheThird (0.00s)\n"}
+{"Time":"2019-06-26T19:28:47.619887526-04:00","Action":"pass","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestParallelTheThird","Elapsed":0}
+{"Time":"2019-06-26T19:28:47.619903436-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestParallelTheSecond","Output":"--- PASS: TestParallelTheSecond (0.01s)\n"}
+{"Time":"2019-06-26T19:28:47.62383803-04:00","Action":"pass","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestParallelTheSecond","Elapsed":0.01}
+{"Time":"2019-06-26T19:28:47.62385879-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestParallelTheFirst","Output":"--- PASS: TestParallelTheFirst (0.01s)\n"}
+{"Time":"2019-06-26T19:28:47.623867697-04:00","Action":"pass","Package":"gotest.tools/gotestsum/testjson/internal/stub","Test":"TestParallelTheFirst","Elapsed":0.01}
+{"Time":"2019-06-26T19:28:47.623872233-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Output":"FAIL\n"}
+{"Time":"2019-06-26T19:28:47.623881112-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Output":"coverage: 0.0% of statements\n"}
+{"Time":"2019-06-26T19:28:47.623967813-04:00","Action":"output","Package":"gotest.tools/gotestsum/testjson/internal/stub","Output":"FAIL\tgotest.tools/gotestsum/testjson/internal/stub\t0.011s\n"}
+{"Time":"2019-06-26T19:28:47.623982468-04:00","Action":"fail","Package":"gotest.tools/gotestsum/testjson/internal/stub","Elapsed":0.011}

--- a/testjson/testdata/short-format-coverage.err
+++ b/testjson/testdata/short-format-coverage.err
@@ -1,0 +1,2 @@
+# gotest.tools/gotestsum/testjson/internal/broken
+internal/broken/broken.go:5:21: undefined: somepackage

--- a/testjson/testdata/short-format-coverage.out
+++ b/testjson/testdata/short-format-coverage.out
@@ -1,0 +1,3 @@
+✖  gotestsum/testjson/internal/badmain (1ms)
+✓  gotestsum/testjson/internal/good (12ms)     (coverage: 0.0% of statements)
+✖  gotestsum/testjson/internal/stub (11ms)     (coverage: 0.0% of statements)

--- a/testjson/testdata/standard-quiet-format-coverage.err
+++ b/testjson/testdata/standard-quiet-format-coverage.err
@@ -1,0 +1,2 @@
+# gotest.tools/gotestsum/testjson/internal/broken
+internal/broken/broken.go:5:21: undefined: somepackage

--- a/testjson/testdata/standard-quiet-format-coverage.out
+++ b/testjson/testdata/standard-quiet-format-coverage.out
@@ -1,0 +1,5 @@
+sometimes main can exit 2
+FAIL	gotest.tools/gotestsum/testjson/internal/badmain	0.001s
+ok  	gotest.tools/gotestsum/testjson/internal/good	0.011s	coverage: 0.0% of statements
+FAIL
+FAIL	gotest.tools/gotestsum/testjson/internal/stub	0.011s


### PR DESCRIPTION
Closes #56

Identify coverage output events with string comparison. There does not appear to be another way.

Add coverage output to the short format, and filter out the duplicate line from the standard-quiet output.