### PR TITLE
Report if a package was cached in short formats

### DIFF
--- a/testjson/execution.go
+++ b/testjson/execution.go
@@ -76,6 +76,8 @@ type Package struct {
 	// with no test failures if an init() or TestMain exits non-zero.
 	// skip indicates there were no tests.
 	action Action
+	// cached is true if the package was marked as (cached)
+	cached bool
 }
 
 // Result returns if the package passed, failed, or was skipped because there
@@ -148,6 +150,9 @@ func (e *Execution) addPackageEvent(pkg *Package, event TestEvent) {
 		if isCoverageOutput(event.Output) {
 			pkg.coverage = strings.TrimRight(event.Output, "\n")
 		}
+		if isCachedOutput(event.Output) {
+			pkg.cached = true
+		}
 		pkg.output[""] = append(pkg.output[""], event.Output)
 	}
 }
@@ -190,6 +195,10 @@ func isCoverageOutput(output string) bool {
 	return all(
 		strings.HasPrefix(output, "coverage:"),
 		strings.HasSuffix(output, "% of statements\n"))
+}
+
+func isCachedOutput(output string) bool {
+	return strings.Contains(output, "\t(cached)")
 }
 
 // Output returns the full test output for a test.

--- a/testjson/format_test.go
+++ b/testjson/format_test.go
@@ -77,6 +77,7 @@ var expectedExecution = &Execution{
 				{Test: "TestSkippedWitLog"},
 			},
 			action: ActionPass,
+			cached: true,
 		},
 		"github.com/gotestyourself/gotestyourself/testjson/internal/stub": {
 			Total: 28,

--- a/testjson/testdata/short-format-coverage.out
+++ b/testjson/testdata/short-format-coverage.out
@@ -1,3 +1,3 @@
 ✖  gotestsum/testjson/internal/badmain (1ms)
-✓  gotestsum/testjson/internal/good (12ms)     (coverage: 0.0% of statements)
-✖  gotestsum/testjson/internal/stub (11ms)     (coverage: 0.0% of statements)
+✓  gotestsum/testjson/internal/good (12ms) (coverage: 0.0% of statements)
+✖  gotestsum/testjson/internal/stub (11ms) (coverage: 0.0% of statements)

--- a/testjson/testdata/short-format.out
+++ b/testjson/testdata/short-format.out
@@ -1,3 +1,3 @@
 ✖  testjson/internal/badmain (10ms)
-✓  testjson/internal/good
+✓  testjson/internal/good (cached)
 ✖  testjson/internal/stub (11ms)

--- a/testjson/testdata/short-verbose-format.out
+++ b/testjson/testdata/short-verbose-format.out
@@ -16,7 +16,7 @@ PASS testjson/internal/good.TestNestedSuccess (0.00s)
 PASS testjson/internal/good.TestParallelTheThird (0.00s)
 PASS testjson/internal/good.TestParallelTheSecond (0.01s)
 PASS testjson/internal/good.TestParallelTheFirst (0.01s)
-PASS testjson/internal/good
+PASS testjson/internal/good (cached)
 PASS testjson/internal/stub.TestPassed (0.00s)
 PASS testjson/internal/stub.TestPassedWithLog (0.00s)
 PASS testjson/internal/stub.TestPassedWithStdout (0.00s)


### PR DESCRIPTION
Closes #58

Include `(cached)` in the output if a package is cached