### PR TITLE
Improve short-verbose output for tests in CWD

### DIFF
--- a/testjson/format.go
+++ b/testjson/format.go
@@ -43,9 +43,20 @@ func standardQuietFormat(event TestEvent, _ *Execution) (string, error) {
 func shortVerboseFormat(event TestEvent, exec *Execution) (string, error) {
 	result := colorEvent(event)(strings.ToUpper(string(event.Action)))
 	formatTest := func() string {
-		return fmt.Sprintf("%s %s.%s %s\n",
+		pkgPath := relativePackagePath(event.Package)
+		// If the package path isn't the current directory, we add
+		// a period to separate the test name and the package path.
+		// If it is the current directory, we don't show it at all.
+		// This prevents output like ..MyTest when the test
+		// is in the current directory.
+		if pkgPath == "." {
+			pkgPath = ""
+		} else {
+			pkgPath += "."
+		}
+		return fmt.Sprintf("%s %s%s %s\n",
 			result,
-			relativePackagePath(event.Package),
+			pkgPath,
 			event.Test,
 			event.ElapsedFormatted())
 	}


### PR DESCRIPTION
Prevents output that looks like this:

```
PASS ..TestHeader/readNegativeLength (0.00s)
PASS ..TestHeader/lengths/124 (0.00s)
PASS ..TestHeader/lengths/131072 (0.00s)
PASS ..TestHeader/lengths/65535 (0.00s)
PASS ..TestHeader/lengths/65537 (0.00s)
PASS ..TestHeader/lengths/65536 (0.00s)
PASS ..TestHeader/lengths/4096 (0.00s)
PASS ..TestHeader/lengths/16384 (0.00s)
PASS ..TestHeader/lengths/125 (0.00s)
PASS ..TestHeader/lengths/126 (0.00s)
PASS ..TestHeader/lengths (0.01s)
PASS ..TestHeader/fuzz (0.33s)
PASS ..TestHeader (0.00s)
```

We don't want the double dots if the test is in the CWD.