### PR TITLE
Junit XML name formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,17 @@ This file can be used to integrate with CI systems.
 gotestsum --junitfile unit-tests.xml
 ```
 
+If the package names in the `testsuite.name` or `testcase.classname` fields do not
+work with your CI system these values can be customized using the
+`--junitfile-testsuite-name`, or `--junitfile-testcase-classname` flags. These flags
+accept the following values:
+
+* `short` - the base name of the package (the single term specified by the 
+  package statement).
+* `relative` - a package path relative to the root of the repository
+* `full` - the full package path (default)
+
+
 ### JSON file output
 
 When the `--jsonfile` flag or `GOTESTSUM_JSONFILE` environment variable are set

--- a/flags.go
+++ b/flags.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"encoding/csv"
+	"path"
 	"strings"
 
 	"github.com/pkg/errors"
+	"gotest.tools/gotestsum/internal/junitxml"
 	"gotest.tools/gotestsum/testjson"
 )
 
@@ -46,4 +48,39 @@ func (s *noSummaryValue) Type() string {
 func (s *noSummaryValue) String() string {
 	// flip all the bits, since the flag value is the negative of what is stored
 	return (testjson.SummarizeAll ^ s.value).String()
+}
+
+var junitFieldFormatValues = "full, relative, short"
+
+type junitFieldFormatValue struct {
+	value junitxml.FormatFunc
+}
+
+func (f *junitFieldFormatValue) Set(val string) error {
+	switch val {
+	case "full":
+		return nil
+	case "relative":
+		f.value = testjson.RelativePackagePath
+		return nil
+	case "short":
+		f.value = path.Base
+		return nil
+	}
+	return errors.Errorf("invalid value: %v, must be one of: "+junitFieldFormatValues, val)
+}
+
+func (f *junitFieldFormatValue) Type() string {
+	return "field-format"
+}
+
+func (f *junitFieldFormatValue) String() string {
+	return "full"
+}
+
+func (f *junitFieldFormatValue) Value() junitxml.FormatFunc {
+	if f == nil {
+		return nil
+	}
+	return f.value
 }

--- a/handler.go
+++ b/handler.go
@@ -69,11 +69,11 @@ func newEventHandler(opts *options, wout io.Writer, werr io.Writer) (*eventHandl
 	return handler, nil
 }
 
-func writeJUnitFile(filename string, execution *testjson.Execution) error {
-	if filename == "" {
+func writeJUnitFile(opts *options, execution *testjson.Execution) error {
+	if opts.junitFile == "" {
 		return nil
 	}
-	junitFile, err := os.Create(filename)
+	junitFile, err := os.Create(opts.junitFile)
 	if err != nil {
 		return errors.Wrap(err, "failed to open JUnit file")
 	}
@@ -83,5 +83,8 @@ func writeJUnitFile(filename string, execution *testjson.Execution) error {
 		}
 	}()
 
-	return junitxml.Write(junitFile, execution)
+	return junitxml.Write(junitFile, execution, junitxml.Config{
+		FormatTestSuiteName:     opts.junitTestSuiteNameFormat.Value(),
+		FormatTestCaseClassname: opts.junitTestCaseClassnameFormat.Value(),
+	})
 }

--- a/internal/junitxml/report_test.go
+++ b/internal/junitxml/report_test.go
@@ -19,7 +19,7 @@ func TestWrite(t *testing.T) {
 	exec := createExecution(t)
 
 	defer env.Patch(t, "GOVERSION", "go7.7.7")()
-	err := Write(out, exec)
+	err := Write(out, exec, Config{})
 	assert.NilError(t, err)
 	golden.Assert(t, out.String(), "junitxml-report.golden")
 }

--- a/main.go
+++ b/main.go
@@ -49,7 +49,11 @@ func main() {
 }
 
 func setupFlags(name string) (*pflag.FlagSet, *options) {
-	opts := &options{noSummary: newNoSummaryValue()}
+	opts := &options{
+		noSummary:                    newNoSummaryValue(),
+		junitTestCaseClassnameFormat: &junitFieldFormatValue{},
+		junitTestSuiteNameFormat:     &junitFieldFormatValue{},
+	}
 	flags := pflag.NewFlagSet(name, pflag.ContinueOnError)
 	flags.SetInterspersed(false)
 	flags.Usage = func() {
@@ -82,7 +86,11 @@ Formats:
 		"write a JUnit XML file")
 	flags.BoolVar(&opts.noColor, "no-color", false, "disable color output")
 	flags.Var(opts.noSummary, "no-summary",
-		fmt.Sprintf("do not print summary of: %s", testjson.SummarizeAll.String()))
+		"do not print summary of: "+testjson.SummarizeAll.String())
+	flags.Var(opts.junitTestSuiteNameFormat, "junitfile-testsuite-name-format",
+		"format the testsuite name field as: "+junitFieldFormatValues)
+	flags.Var(opts.junitTestCaseClassnameFormat, "junitfile-testcase-classname-format",
+		"format the testcase classname field as: "+junitFieldFormatValues)
 	flags.BoolVar(&opts.version, "version", false, "show version and exit")
 	return flags, opts
 }
@@ -95,15 +103,17 @@ func lookEnvWithDefault(key, defValue string) string {
 }
 
 type options struct {
-	args       []string
-	format     string
-	debug      bool
-	rawCommand bool
-	jsonFile   string
-	junitFile  string
-	noColor    bool
-	noSummary  *noSummaryValue
-	version    bool
+	args                         []string
+	format                       string
+	debug                        bool
+	rawCommand                   bool
+	jsonFile                     string
+	junitFile                    string
+	noColor                      bool
+	noSummary                    *noSummaryValue
+	junitTestSuiteNameFormat     *junitFieldFormatValue
+	junitTestCaseClassnameFormat *junitFieldFormatValue
+	version                      bool
 }
 
 func setupLogging(opts *options) {
@@ -141,7 +151,7 @@ func run(opts *options) error {
 	if err := testjson.PrintSummary(out, exec, opts.noSummary.value); err != nil {
 		return err
 	}
-	if err := writeJUnitFile(opts.junitFile, exec); err != nil {
+	if err := writeJUnitFile(opts, exec); err != nil {
 		return err
 	}
 	return goTestProc.cmd.Wait()

--- a/main.go
+++ b/main.go
@@ -87,9 +87,9 @@ Formats:
 	flags.BoolVar(&opts.noColor, "no-color", false, "disable color output")
 	flags.Var(opts.noSummary, "no-summary",
 		"do not print summary of: "+testjson.SummarizeAll.String())
-	flags.Var(opts.junitTestSuiteNameFormat, "junitfile-testsuite-name-format",
+	flags.Var(opts.junitTestSuiteNameFormat, "junitfile-testsuite-name",
 		"format the testsuite name field as: "+junitFieldFormatValues)
-	flags.Var(opts.junitTestCaseClassnameFormat, "junitfile-testcase-classname-format",
+	flags.Var(opts.junitTestCaseClassnameFormat, "junitfile-testcase-classname",
 		"format the testcase classname field as: "+junitFieldFormatValues)
 	flags.BoolVar(&opts.version, "version", false, "show version and exit")
 	return flags, opts

--- a/testjson/format.go
+++ b/testjson/format.go
@@ -43,7 +43,7 @@ func standardQuietFormat(event TestEvent, _ *Execution) (string, error) {
 func shortVerboseFormat(event TestEvent, exec *Execution) (string, error) {
 	result := colorEvent(event)(strings.ToUpper(string(event.Action)))
 	formatTest := func() string {
-		pkgPath := relativePackagePath(event.Package)
+		pkgPath := RelativePackagePath(event.Package)
 		// If the package path isn't the current directory, we add
 		// a period to separate the test name and the package path.
 		// If it is the current directory, we don't show it at all.
@@ -77,7 +77,7 @@ func shortVerboseFormat(event TestEvent, exec *Execution) (string, error) {
 			}
 			return fmt.Sprintf("%s %s%s\n",
 				result,
-				relativePackagePath(event.Package),
+				RelativePackagePath(event.Package),
 				cached), nil
 		}
 
@@ -144,7 +144,7 @@ func shortFormat(event TestEvent, exec *Execution) (string, error) {
 	fmtEvent := func(action string) (string, error) {
 		return fmt.Sprintf("%s  %s%s%s\n",
 			action,
-			relativePackagePath(event.Package),
+			RelativePackagePath(event.Package),
 			fmtElapsed(),
 			fmtCoverage(),
 		), nil
@@ -169,7 +169,7 @@ func dotsFormat(event TestEvent, exec *Execution) (string, error) {
 	case event.PackageEvent():
 		return "", nil
 	case event.Action == ActionRun && pkg.Total == 1:
-		return "[" + relativePackagePath(event.Package) + "]", nil
+		return "[" + RelativePackagePath(event.Package) + "]", nil
 	case event.Action == ActionPass:
 		return withColor("·"), nil
 	case event.Action == ActionFail:

--- a/testjson/pkgpathprefix.go
+++ b/testjson/pkgpathprefix.go
@@ -11,7 +11,13 @@ import (
 	"strings"
 )
 
-func relativePackagePath(pkgpath string) string {
+// RelativePackagePath attempts to remove a common prefix from a package path.
+// The common prefix is determined either by looking at the GOPATH or reading
+// the package value from go.mod file.
+// If the pkgpath does not match the common prefix it will be returned
+// unmodified.
+// If the pkgpath matches the common prefix exactly then '.' will be returned.
+func RelativePackagePath(pkgpath string) string {
 	if pkgpath == pkgPathPrefix {
 		return "."
 	}

--- a/testjson/pkgpathprefix_test.go
+++ b/testjson/pkgpathprefix_test.go
@@ -10,10 +10,10 @@ import (
 func TestRelativePackagePath(t *testing.T) {
 	prefix := "gotest.tools/gotestsum/testjson"
 	defer patchPkgPathPrefix(prefix)()
-	relPath := relativePackagePath(prefix + "/extra/relpath")
+	relPath := RelativePackagePath(prefix + "/extra/relpath")
 	assert.Equal(t, relPath, "extra/relpath")
 
-	relPath = relativePackagePath(prefix)
+	relPath = RelativePackagePath(prefix)
 	assert.Equal(t, relPath, ".")
 }
 

--- a/testjson/summary.go
+++ b/testjson/summary.go
@@ -161,7 +161,7 @@ func writeTestCaseSummary(out io.Writer, execution executionSummary, conf testCa
 	for _, tc := range testCases {
 		fmt.Fprintf(out, "=== %s: %s %s (%s)\n",
 			conf.prefix,
-			relativePackagePath(tc.Package),
+			RelativePackagePath(tc.Package),
 			tc.Test,
 			FormatDurationAsSeconds(tc.Elapsed, 2))
 		for _, line := range execution.OutputLines(tc.Package, tc.Test) {


### PR DESCRIPTION
Fixes #50 
Fixes #68 
Closes #69 

Add new command line flags for configuring the format of the junit-xml output.

The flag names are unfortunately quite long, but I think shorter names might not be sufficient in this case.