### PR TITLE
Add short-with-failures format

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ gotestsum --format short-verbose
 Supported formats:
  * `dots` - output one character per test.
  * `short` (default) - output a line for each test package.
+ * `short-with-failures` - like short, but prints test output as soon as a test
+   fails.
  * `standard-quiet` - the default `go test` format.
  * `short-verbose` - output a line for each test and package.
  * `standard-verbose` - the standard `go test -v` format.

--- a/README.md
+++ b/README.md
@@ -37,12 +37,11 @@ gotestsum --format short-verbose
 ```
 
 Supported formats:
- * `dots` - output one character per test.
- * `short` (default) - output a line for each test package.
- * `short-with-failures` - like short, but prints test output as soon as a test
-   fails.
- * `standard-quiet` - the default `go test` format.
- * `short-verbose` - output a line for each test and package.
+ * `dots` - print a character for each test.
+ * `short` (default) - print a line for each package.
+ * `short-with-failures` - print a line for each package and failed test output.
+ * `short-verbose` - print a line for each test and package.
+ * `standard-quiet` - the standard `go test` format.
  * `standard-verbose` - the standard `go test -v` format.
 
 Have a suggestion for some other format? Please open an issue!

--- a/main.go
+++ b/main.go
@@ -65,11 +65,12 @@ Flags:
 		flags.PrintDefaults()
 		fmt.Fprint(os.Stderr, `
 Formats:
-    dots              print a character for each test
-    short             print a line for each package
-    short-verbose     print a line for each test and package
-    standard-quiet    default go test format
-    standard-verbose  default go test -v format
+    dots                print a character for each test
+    short               print a line for each package
+    short-with-failures print a line for each package and failed test output
+    short-verbose       print a line for each test and package
+    standard-quiet      standard go test format
+    standard-verbose    standard go test -v format
 `)
 	}
 	flags.BoolVar(&opts.debug, "debug", false, "enabled debug")

--- a/testjson/format.go
+++ b/testjson/format.go
@@ -123,6 +123,10 @@ func shortFormat(event TestEvent, exec *Execution) (string, error) {
 	if !event.PackageEvent() {
 		return "", nil
 	}
+	return shortFormatPackageEvent(event, exec)
+}
+
+func shortFormatPackageEvent(event TestEvent, exec *Execution) (string, error) {
 	pkg := exec.Package(event.Package)
 
 	fmtElapsed := func() string {
@@ -159,6 +163,16 @@ func shortFormat(event TestEvent, exec *Execution) (string, error) {
 		return fmtEvent(withColor("✖"))
 	}
 	return "", nil
+}
+
+func shortWithFailuresFormat(event TestEvent, exec *Execution) (string, error) {
+	if !event.PackageEvent() {
+		if event.Action == ActionFail {
+			return exec.Output(event.Package, event.Test), nil
+		}
+		return "", nil
+	}
+	return shortFormatPackageEvent(event, exec)
 }
 
 func dotsFormat(event TestEvent, exec *Execution) (string, error) {
@@ -207,6 +221,8 @@ func NewEventFormatter(format string) EventFormatter {
 		return shortVerboseFormat
 	case "short":
 		return shortFormat
+	case "short-with-failures":
+		return shortWithFailuresFormat
 	default:
 		return nil
 	}


### PR DESCRIPTION
Closes #72

Adds a new format, similar to `short`, that prints test output as soon as a test fails. Useful when a test suite runs for a long time and you want to see errors before the run ends.