### PR TITLE
Re-add the original dots format

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,10 @@ workflows:
       - build
       - run
 
+      - update-windows-golden:
+          filters:
+            branches: {ignore: '/.*/'}
+
       - build:
           name: release
           publish: true

--- a/internal/dotwriter/writer.go
+++ b/internal/dotwriter/writer.go
@@ -29,7 +29,7 @@ func (w *Writer) Flush() error {
 	if w.buf.Len() == 0 {
 		return nil
 	}
-	w.clearLines()
+	w.clearLines(w.lineCount)
 	w.lineCount = bytes.Count(w.buf.Bytes(), []byte{'\n'})
 	_, err := w.out.Write(w.buf.Bytes())
 	w.buf.Reset()

--- a/internal/dotwriter/writer_posix.go
+++ b/internal/dotwriter/writer_posix.go
@@ -10,6 +10,6 @@ import (
 // clear the line and move the cursor up
 var clear = fmt.Sprintf("%c[%dA%c[2K", ESC, 1, ESC)
 
-func (w *Writer) clearLines() {
-	_, _ = fmt.Fprint(w.out, strings.Repeat(clear, w.lineCount))
+func (w *Writer) clearLines(count int) {
+	_, _ = fmt.Fprint(w.out, strings.Repeat(clear, count))
 }

--- a/internal/dotwriter/writer_windows.go
+++ b/internal/dotwriter/writer_windows.go
@@ -52,20 +52,20 @@ type fdWriter interface {
 	Fd() uintptr
 }
 
-func (w *Writer) clearLines() {
+func (w *Writer) clearLines(count int) {
 	f, ok := w.out.(fdWriter)
 	if ok && !isatty.IsTerminal(f.Fd()) {
 		ok = false
 	}
 	if !ok {
-		_, _ = fmt.Fprint(w.out, strings.Repeat(clear, w.lineCount))
+		_, _ = fmt.Fprint(w.out, strings.Repeat(clear, count))
 		return
 	}
 	fd := f.Fd()
 	var csbi consoleScreenBufferInfo
 	_, _, _ = procGetConsoleScreenBufferInfo.Call(fd, uintptr(unsafe.Pointer(&csbi)))
 
-	for i := 0; i < w.lineCount; i++ {
+	for i := 0; i < count; i++ {
 		// move the cursor up
 		csbi.cursorPosition.y--
 		_, _, _ = procSetConsoleCursorPosition.Call(fd, uintptr(*(*int32)(unsafe.Pointer(&csbi.cursorPosition))))

--- a/main.go
+++ b/main.go
@@ -66,6 +66,7 @@ Flags:
 		fmt.Fprint(os.Stderr, `
 Formats:
     dots                    print a character for each test
+    dots-compact            dots, without the newlines
     pkgname                 print a line for each package
     pkgname-and-test-fails  print a line for each package and failed test output
     testname                print a line for each test and package

--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ Flags:
 		fmt.Fprint(os.Stderr, `
 Formats:
     dots                    print a character for each test
-    dots-compact            dots, without the newlines
+    dots-v2                 experimental dots format, one package per line
     pkgname                 print a line for each package
     pkgname-and-test-fails  print a line for each package and failed test output
     testname                print a line for each test and package

--- a/testjson/dotformat.go
+++ b/testjson/dotformat.go
@@ -96,6 +96,9 @@ func (d *dotFormatter) Format(event TestEvent, exec *Execution) error {
 		return nil
 	}
 
+	// Add an empty header to work around incorrect line counting
+	fmt.Fprint(d.writer, "\n\n")
+
 	sort.Slice(d.order, d.orderByLastUpdated)
 	for _, pkg := range d.order {
 		line := d.pkgs[pkg]

--- a/testjson/format.go
+++ b/testjson/format.go
@@ -198,10 +198,10 @@ func NewEventFormatter(out io.Writer, format string) EventFormatter {
 		return &formatAdapter{out, standardVerboseFormat}
 	case "standard-quiet":
 		return &formatAdapter{out, standardQuietFormat}
-	case "dots":
-		return newDotFormatter(out)
-	case "dots-compact":
+	case "dots", "dots-v1":
 		return &formatAdapter{out, dotsFormatV1}
+	case "dots-v2":
+		return newDotFormatter(out)
 	case "testname", "short-verbose":
 		return &formatAdapter{out, shortVerboseFormat}
 	case "pkgname", "short":

--- a/testjson/format.go
+++ b/testjson/format.go
@@ -200,6 +200,8 @@ func NewEventFormatter(out io.Writer, format string) EventFormatter {
 		return &formatAdapter{out, standardQuietFormat}
 	case "dots":
 		return newDotFormatter(out)
+	case "dots-compact":
+		return &formatAdapter{out, dotsFormatV1}
 	case "testname", "short-verbose":
 		return &formatAdapter{out, shortVerboseFormat}
 	case "pkgname", "short":

--- a/testjson/testdata/dots-format-windows.out
+++ b/testjson/testdata/dots-format-windows.out
@@ -1,489 +1,703 @@
+
+
        testjson/internal/badmain 
 
  0 tests, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good 
 
  1 tests, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ·
 
  1 tests, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ·
 
  2 tests, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ··
 
  2 tests, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ··
 
  3 tests, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···
 
  3 tests, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···
 
  4 tests, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷
 
  4 tests, 1 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷
 
  5 tests, 1 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷
 
  5 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷
 
  6 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  6 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  7 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  7 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  8 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  8 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  9 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  9 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  10 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  11 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  12 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  13 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  14 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  15 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  16 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  17 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  18 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷··
 
  18 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷···
 
  18 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷····
 
  18 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷·····
 
  18 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷······
 
  18 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷·······
 
  18 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷········
 
  18 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷·········
 
  18 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷··········
 
  18 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷··········
 
  18 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷··········
 
  18 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷··········
 
  18 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷···········
 
  18 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
   10ms testjson/internal/good ···↷↷············
 
  18 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
   20ms testjson/internal/good ···↷↷·············
 
  18 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
 
  18 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub 
 
  19 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ·
 
  19 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ·
 
  20 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ··
 
  20 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ··
 
  21 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···
 
  21 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···
 
  22 tests, 2 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷
 
  22 tests, 3 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷
 
  23 tests, 3 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷
 
  23 tests, 4 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷
 
  24 tests, 4 skipped, 1 failure, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖
 
  24 tests, 4 skipped, 2 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖
 
  25 tests, 4 skipped, 2 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·
 
  25 tests, 4 skipped, 2 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·
 
  26 tests, 4 skipped, 2 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  26 tests, 4 skipped, 3 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  27 tests, 4 skipped, 3 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  27 tests, 4 skipped, 3 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  28 tests, 4 skipped, 3 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  28 tests, 4 skipped, 3 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  29 tests, 4 skipped, 3 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  29 tests, 4 skipped, 3 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  30 tests, 4 skipped, 3 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  31 tests, 4 skipped, 3 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  32 tests, 4 skipped, 3 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  33 tests, 4 skipped, 3 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  34 tests, 4 skipped, 3 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  35 tests, 4 skipped, 3 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  36 tests, 4 skipped, 3 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  37 tests, 4 skipped, 3 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖·
 
  37 tests, 4 skipped, 3 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖··
 
  37 tests, 4 skipped, 3 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖···
 
  37 tests, 4 skipped, 3 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····
 
  37 tests, 4 skipped, 3 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖
 
  37 tests, 4 skipped, 4 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖·
 
  37 tests, 4 skipped, 4 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··
 
  37 tests, 4 skipped, 4 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖
 
  37 tests, 4 skipped, 5 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖
 
  38 tests, 4 skipped, 5 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖
 
  39 tests, 4 skipped, 5 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖
 
  40 tests, 4 skipped, 5 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖
 
  41 tests, 4 skipped, 5 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖
 
  42 tests, 4 skipped, 5 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖
 
  43 tests, 4 skipped, 5 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖
 
  44 tests, 4 skipped, 5 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖
 
  45 tests, 4 skipped, 5 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖
 
  46 tests, 4 skipped, 5 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖·
 
  46 tests, 4 skipped, 5 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖··
 
  46 tests, 4 skipped, 5 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖···
 
  46 tests, 4 skipped, 5 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖····
 
  46 tests, 4 skipped, 5 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖·····
 
  46 tests, 4 skipped, 5 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖······
 
  46 tests, 4 skipped, 5 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖·······
 
  46 tests, 4 skipped, 5 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖········
 
  46 tests, 4 skipped, 5 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖·········
 
  46 tests, 4 skipped, 5 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖·········
 
  46 tests, 4 skipped, 5 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖·········
 
  46 tests, 4 skipped, 5 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖·········
 
  46 tests, 4 skipped, 5 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖··········
 
  46 tests, 4 skipped, 5 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
   10ms testjson/internal/stub ···↷↷✖·✖····✖··✖···········
 
  46 tests, 4 skipped, 5 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
   20ms testjson/internal/stub ···↷↷✖·✖····✖··✖············
 
  46 tests, 4 skipped, 5 failures, 1 error
-[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K       testjson/internal/badmain 
+[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K[0A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
   20ms testjson/internal/stub ···↷↷✖·✖····✖··✖············
 

--- a/testjson/testdata/dots-format.out
+++ b/testjson/testdata/dots-format.out
@@ -1,489 +1,703 @@
+
+
        testjson/internal/badmain 
 
  0 tests, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good 
 
  1 tests, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ·
 
  1 tests, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ·
 
  2 tests, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ··
 
  2 tests, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ··
 
  3 tests, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···
 
  3 tests, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···
 
  4 tests, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷
 
  4 tests, 1 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷
 
  5 tests, 1 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷
 
  5 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷
 
  6 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  6 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  7 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  7 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  8 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  8 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  9 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  9 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  10 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  11 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  12 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  13 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  14 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  15 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  16 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  17 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  18 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷··
 
  18 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷···
 
  18 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷····
 
  18 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷·····
 
  18 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷······
 
  18 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷·······
 
  18 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷········
 
  18 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷·········
 
  18 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷··········
 
  18 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷··········
 
  18 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷··········
 
  18 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷··········
 
  18 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
        testjson/internal/good ···↷↷···········
 
  18 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
   10ms testjson/internal/good ···↷↷············
 
  18 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
   20ms testjson/internal/good ···↷↷·············
 
  18 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
 
  18 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub 
 
  19 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ·
 
  19 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ·
 
  20 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ··
 
  20 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ··
 
  21 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···
 
  21 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···
 
  22 tests, 2 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷
 
  22 tests, 3 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷
 
  23 tests, 3 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷
 
  23 tests, 4 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷
 
  24 tests, 4 skipped, 1 failure, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖
 
  24 tests, 4 skipped, 2 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖
 
  25 tests, 4 skipped, 2 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·
 
  25 tests, 4 skipped, 2 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·
 
  26 tests, 4 skipped, 2 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  26 tests, 4 skipped, 3 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  27 tests, 4 skipped, 3 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  27 tests, 4 skipped, 3 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  28 tests, 4 skipped, 3 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  28 tests, 4 skipped, 3 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  29 tests, 4 skipped, 3 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  29 tests, 4 skipped, 3 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  30 tests, 4 skipped, 3 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  31 tests, 4 skipped, 3 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  32 tests, 4 skipped, 3 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  33 tests, 4 skipped, 3 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  34 tests, 4 skipped, 3 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  35 tests, 4 skipped, 3 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  36 tests, 4 skipped, 3 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  37 tests, 4 skipped, 3 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖·
 
  37 tests, 4 skipped, 3 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖··
 
  37 tests, 4 skipped, 3 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖···
 
  37 tests, 4 skipped, 3 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····
 
  37 tests, 4 skipped, 3 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖
 
  37 tests, 4 skipped, 4 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖·
 
  37 tests, 4 skipped, 4 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··
 
  37 tests, 4 skipped, 4 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖
 
  37 tests, 4 skipped, 5 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖
 
  38 tests, 4 skipped, 5 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖
 
  39 tests, 4 skipped, 5 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖
 
  40 tests, 4 skipped, 5 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖
 
  41 tests, 4 skipped, 5 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖
 
  42 tests, 4 skipped, 5 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖
 
  43 tests, 4 skipped, 5 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖
 
  44 tests, 4 skipped, 5 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖
 
  45 tests, 4 skipped, 5 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖
 
  46 tests, 4 skipped, 5 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖·
 
  46 tests, 4 skipped, 5 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖··
 
  46 tests, 4 skipped, 5 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖···
 
  46 tests, 4 skipped, 5 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖····
 
  46 tests, 4 skipped, 5 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖·····
 
  46 tests, 4 skipped, 5 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖······
 
  46 tests, 4 skipped, 5 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖·······
 
  46 tests, 4 skipped, 5 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖········
 
  46 tests, 4 skipped, 5 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖·········
 
  46 tests, 4 skipped, 5 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖·········
 
  46 tests, 4 skipped, 5 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖·········
 
  46 tests, 4 skipped, 5 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖·········
 
  46 tests, 4 skipped, 5 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖··········
 
  46 tests, 4 skipped, 5 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
   10ms testjson/internal/stub ···↷↷✖·✖····✖··✖···········
 
  46 tests, 4 skipped, 5 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
   20ms testjson/internal/stub ···↷↷✖·✖····✖··✖············
 
  46 tests, 4 skipped, 5 failures, 1 error
-[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K       testjson/internal/badmain 
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
   20ms testjson/internal/stub ···↷↷✖·✖····✖··✖············
 


### PR DESCRIPTION
Relates to #88

Restore the old `dots` format. Use `dots-v2` for the new dynamic format.

Attempt to fix the v2 output with some leading empty new lines.

