### PR TITLE
Add -t flag to test2json examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ that `gotestsum` expects.
 Example:
 
 ```
-gotestsum --raw-command -- go tool test2json -p pkgname ./binary.test -test.v
+gotestsum --raw-command -- go tool test2json -t -p pkgname ./binary.test -test.v
 ```
 
 `pkgname` is the name of the package being tested, it will show up in the test

--- a/docs/running-without-go.md
+++ b/docs/running-without-go.md
@@ -17,6 +17,6 @@ mv test2json /usr/local/bin/test2json
 Example: running without a Go installation
 ```
 export GOVERSION=1.13
-gotestsum --raw-command -- test2json -p pkgname ./binary.test -test.v
+gotestsum --raw-command -- test2json -t -p pkgname ./binary.test -test.v
 ```
 


### PR DESCRIPTION
Fixes #96 

This seems to be required to get elapsed time. See https://github.com/gotestyourself/gotestsum/issues/96