### PR TITLE
mitigate test2json bug causing missing test output

### DIFF
--- a/internal/junitxml/report.go
+++ b/internal/junitxml/report.go
@@ -155,14 +155,16 @@ func packageTestCases(pkg *testjson.Package, formatClassname FormatFunc) []JUnit
 		jtc := newJUnitTestCase(tc, formatClassname)
 		jtc.Failure = &JUnitFailure{
 			Message:  "Failed",
-			Contents: pkg.Output(tc.Test),
+			Contents: strings.Join(pkg.OutputLines(tc), ""),
 		}
 		cases = append(cases, jtc)
 	}
 
 	for _, tc := range pkg.Skipped {
 		jtc := newJUnitTestCase(tc, formatClassname)
-		jtc.SkipMessage = &JUnitSkipMessage{Message: pkg.Output(tc.Test)}
+		jtc.SkipMessage = &JUnitSkipMessage{
+			Message: strings.Join(pkg.OutputLines(tc), ""),
+		}
 		cases = append(cases, jtc)
 	}
 

--- a/testjson/execution.go
+++ b/testjson/execution.go
@@ -69,7 +69,11 @@ type Package struct {
 	Failed  []TestCase
 	Skipped []TestCase
 	Passed  []TestCase
-	output  map[string][]string
+	// output printed by test cases. Output is stored first by root TestCase
+	// name, then by subtest name to mitigate github.com/golang/go/issues/29755.
+	// In the future when that bug is fixed this can be reverted to store all
+	// output by full test name.
+	output map[string]map[string][]string
 	// coverage stores the code coverage output for the package without the
 	// trailing newline (ex: coverage: 91.1% of statements).
 	coverage string
@@ -106,7 +110,27 @@ func (p Package) TestCases() []TestCase {
 
 // Output returns the full test output for a test.
 func (p Package) Output(test string) string {
-	return strings.Join(p.output[test], "")
+	root, sub := splitTestName(test)
+	return strings.Join(p.output[root][sub], "")
+}
+
+func (p Package) addOutput(test string, output string) {
+	root, sub := splitTestName(test)
+	if p.output[root] == nil {
+		p.output[root] = make(map[string][]string)
+	}
+	// TODO: limit size of buffered test output
+	p.output[root][sub] = append(p.output[root][sub], output)
+
+}
+
+// splitTestName into root test name and any subtest names.
+func splitTestName(name string) (root, sub string) {
+	parts := strings.SplitN(name, "/", 2)
+	if len(parts) < 2 {
+		return name, ""
+	}
+	return parts[0], parts[1]
 }
 
 // TestMainFailed returns true if the package failed, but there were no tests.
@@ -134,7 +158,7 @@ type TestCase struct {
 
 func newPackage() *Package {
 	return &Package{
-		output:  make(map[string][]string),
+		output:  make(map[string]map[string][]string),
 		running: make(map[string]TestCase),
 	}
 }
@@ -171,7 +195,7 @@ func (e *Execution) addPackageEvent(pkg *Package, event TestEvent) {
 		if isCachedOutput(event.Output) {
 			pkg.cached = true
 		}
-		pkg.output[""] = append(pkg.output[""], event.Output)
+		pkg.addOutput("", event.Output)
 	}
 }
 
@@ -185,8 +209,7 @@ func (e *Execution) addTestEvent(pkg *Package, event TestEvent) {
 		}
 		return
 	case ActionOutput, ActionBench:
-		// TODO: limit size of buffered test output
-		pkg.output[event.Test] = append(pkg.output[event.Test], event.Output)
+		pkg.addOutput(event.Test, event.Output)
 		return
 	case ActionPause, ActionCont:
 		return
@@ -222,14 +245,10 @@ func isCachedOutput(output string) bool {
 	return strings.Contains(output, "\t(cached)")
 }
 
-// Output returns the full test output for a test.
-func (e *Execution) Output(pkg, test string) string {
-	return strings.Join(e.packages[pkg].output[test], "")
-}
-
 // OutputLines returns the full test output for a test as an array of lines.
 func (e *Execution) OutputLines(pkg, test string) []string {
-	return e.packages[pkg].output[test]
+	root, sub := splitTestName(test)
+	return e.packages[pkg].output[root][sub]
 }
 
 // Package returns the Package by name.

--- a/testjson/execution_test.go
+++ b/testjson/execution_test.go
@@ -35,8 +35,10 @@ func TestExecution_Add_PackageCoverage(t *testing.T) {
 	pkg := exec.Package("mytestpkg")
 	expected := &Package{
 		coverage: "coverage: 33.1% of statements",
-		output: map[string][]string{
-			"": {"coverage: 33.1% of statements\n"},
+		output: map[string]map[string][]string{
+			"": {
+				"": {"coverage: 33.1% of statements\n"},
+			},
 		},
 		running: map[string]TestCase{},
 	}

--- a/testjson/format.go
+++ b/testjson/format.go
@@ -79,7 +79,7 @@ func shortVerboseFormat(event TestEvent, exec *Execution) (string, error) {
 		}
 
 	case event.Action == ActionFail:
-		return exec.Output(event.Package, event.Test) + formatTest(), nil
+		return exec.Package(event.Package).Output(event.Test) + formatTest(), nil
 
 	case event.Action == ActionPass:
 		return formatTest(), nil
@@ -164,7 +164,7 @@ func shortFormatPackageEvent(event TestEvent, exec *Execution) (string, error) {
 func shortWithFailuresFormat(event TestEvent, exec *Execution) (string, error) {
 	if !event.PackageEvent() {
 		if event.Action == ActionFail {
-			return exec.Output(event.Package, event.Test), nil
+			return exec.Package(event.Package).Output(event.Test), nil
 		}
 		return "", nil
 	}

--- a/testjson/summary.go
+++ b/testjson/summary.go
@@ -174,7 +174,7 @@ func writeTestCaseSummary(out io.Writer, execution executionSummary, conf testCa
 			tc.Test,
 			FormatDurationAsSeconds(tc.Elapsed, 2))
 		for _, line := range execution.OutputLines(tc.Package, tc.Test) {
-			if isRunLine(line) || conf.filter(line) {
+			if isRunLine(line) || conf.filter(tc.Test, line) {
 				continue
 			}
 			fmt.Fprint(out, line)
@@ -186,7 +186,7 @@ func writeTestCaseSummary(out io.Writer, execution executionSummary, conf testCa
 type testCaseFormatConfig struct {
 	header string
 	prefix string
-	filter func(string) bool
+	filter func(testName string, line string) bool
 	getter func(executionSummary) []TestCase
 }
 
@@ -195,8 +195,8 @@ func formatFailed() testCaseFormatConfig {
 	return testCaseFormatConfig{
 		header: withColor("Failed"),
 		prefix: withColor("FAIL"),
-		filter: func(line string) bool {
-			return strings.HasPrefix(line, "--- FAIL: Test")
+		filter: func(testName string, line string) bool {
+			return strings.HasPrefix(line, "--- FAIL: "+testName+" ")
 		},
 		getter: func(execution executionSummary) []TestCase {
 			return execution.Failed()
@@ -209,8 +209,8 @@ func formatSkipped() testCaseFormatConfig {
 	return testCaseFormatConfig{
 		header: withColor("Skipped"),
 		prefix: withColor("SKIP"),
-		filter: func(line string) bool {
-			return strings.HasPrefix(line, "--- SKIP: Test")
+		filter: func(testName string, line string) bool {
+			return strings.HasPrefix(line, "--- SKIP: "+testName+" ")
 		},
 		getter: func(execution executionSummary) []TestCase {
 			return execution.Skipped()

--- a/testjson/summary.go
+++ b/testjson/summary.go
@@ -143,14 +143,14 @@ func countErrors(errors []string) int {
 type executionSummary interface {
 	Failed() []TestCase
 	Skipped() []TestCase
-	OutputLines(pkg, test string) []string
+	OutputLines(TestCase) []string
 }
 
 type noOutputSummary struct {
 	Execution
 }
 
-func (s *noOutputSummary) OutputLines(_, _ string) []string {
+func (s *noOutputSummary) OutputLines(_ TestCase) []string {
 	return nil
 }
 
@@ -173,7 +173,7 @@ func writeTestCaseSummary(out io.Writer, execution executionSummary, conf testCa
 			RelativePackagePath(tc.Package),
 			tc.Test,
 			FormatDurationAsSeconds(tc.Elapsed, 2))
-		for _, line := range execution.OutputLines(tc.Package, tc.Test) {
+		for _, line := range execution.OutputLines(tc) {
 			if isRunLine(line) || conf.filter(tc.Test, line) {
 				continue
 			}

--- a/testjson/summary_test.go
+++ b/testjson/summary_test.go
@@ -88,7 +88,7 @@ func TestPrintSummary_WithFailures(t *testing.T) {
 						Elapsed: 12 * time.Millisecond,
 					},
 				},
-				output: map[string][]string{
+				output: map[string]map[string][]string{
 					"TestFileDo": multiLine(`=== RUN   TestFileDo
 Some stdout/stderr here
 --- FAIL: TestFailDo (1.41s)
@@ -98,7 +98,7 @@ Some stdout/stderr here
 --- FAIL: TestFailDoError (0.01s)
 	do_test.go:50 assertion failed: expected nil error, got WHAT!
 `),
-					"": {"FAIL\n"},
+					"": multiLine("FAIL\n"),
 				},
 				action: ActionFail,
 			},
@@ -118,7 +118,7 @@ Some stdout/stderr here
 						Elapsed: 0,
 					},
 				},
-				output: map[string][]string{
+				output: map[string]map[string][]string{
 					"TestAlbatross": multiLine(`=== RUN   TestAlbatross
 --- FAIL: TestAlbatross (0.04s)
 `),
@@ -130,8 +130,8 @@ Some stdout/stderr here
 			},
 			"example.com/project/badmain": {
 				action: ActionFail,
-				output: map[string][]string{
-					"": {"sometimes main can exit 2\n"},
+				output: map[string]map[string][]string{
+					"": multiLine("sometimes main can exit 2\n"),
 				},
 			},
 		},
@@ -220,8 +220,10 @@ func patchClock() (clockwork.FakeClock, func()) {
 	return fake, func() { clock = clockwork.NewRealClock() }
 }
 
-func multiLine(s string) []string {
-	return strings.SplitAfter(s, "\n")
+func multiLine(s string) map[string][]string {
+	return map[string][]string{
+		"": strings.SplitAfter(s, "\n"),
+	}
 }
 
 func TestPrintSummary_MissingTestFailEvent(t *testing.T) {

--- a/testjson/summary_test.go
+++ b/testjson/summary_test.go
@@ -91,11 +91,11 @@ func TestPrintSummary_WithFailures(t *testing.T) {
 				output: map[string]map[string][]string{
 					"TestFileDo": multiLine(`=== RUN   TestFileDo
 Some stdout/stderr here
---- FAIL: TestFailDo (1.41s)
+--- FAIL: TestFileDo (1.41s)
 	do_test.go:33 assertion failed
 `),
 					"TestFileDoError": multiLine(`=== RUN   TestFileDoError
---- FAIL: TestFailDoError (0.01s)
+--- FAIL: TestFileDoError (0.01s)
 	do_test.go:50 assertion failed: expected nil error, got WHAT!
 `),
 					"": multiLine("FAIL\n"),

--- a/testjson/testdata/go-test-json-misattributed.out
+++ b/testjson/testdata/go-test-json-misattributed.out
@@ -1,0 +1,35 @@
+{"Action":"run","Test":"TestOutputWithSubtest"}
+{"Action":"output","Test":"TestOutputWithSubtest","Output":"=== RUN   TestOutputWithSubtest\n"}
+{"Action":"run","Test":"TestOutputWithSubtest/sub_test"}
+{"Action":"output","Test":"TestOutputWithSubtest/sub_test","Output":"=== RUN   TestOutputWithSubtest/sub_test\n"}
+{"Action":"run","Test":"TestOutputWithSubtest/sub_test/sub2"}
+{"Action":"output","Test":"TestOutputWithSubtest/sub_test/sub2","Output":"=== RUN   TestOutputWithSubtest/sub_test/sub2\n"}
+{"Action":"run","Test":"TestOutputWithSubtest/sub_test2"}
+{"Action":"output","Test":"TestOutputWithSubtest/sub_test2","Output":"=== RUN   TestOutputWithSubtest/sub_test2\n"}
+{"Action":"run","Test":"TestOutputWithSubtest/sub_test2/sub2"}
+{"Action":"output","Test":"TestOutputWithSubtest/sub_test2/sub2","Output":"=== RUN   TestOutputWithSubtest/sub_test2/sub2\n"}
+{"Action":"output","Test":"TestOutputWithSubtest","Output":"--- FAIL: TestOutputWithSubtest (0.00s)\n"}
+{"Action":"output","Test":"TestOutputWithSubtest/sub_test","Output":"    --- PASS: TestOutputWithSubtest/sub_test (0.00s)\n"}
+{"Action":"output","Test":"TestOutputWithSubtest/sub_test","Output":"        foo_test.go:9: output from sub test\n"}
+{"Action":"output","Test":"TestOutputWithSubtest/sub_test","Output":"        foo_test.go:11: more output from sub test\n"}
+{"Action":"output","Test":"TestOutputWithSubtest/sub_test","Output":"        foo_test.go:16: more output from sub test\n"}
+{"Action":"output","Test":"TestOutputWithSubtest/sub_test/sub2","Output":"        --- PASS: TestOutputWithSubtest/sub_test/sub2 (0.00s)\n"}
+{"Action":"output","Test":"TestOutputWithSubtest/sub_test/sub2","Output":"            foo_test.go:14: output from sub2 test\n"}
+{"Action":"output","Test":"TestOutputWithSubtest/sub_test/sub2","Output":"    foo_test.go:22: output from root test\n"}
+{"Action":"output","Test":"TestOutputWithSubtest/sub_test/sub2","Output":"    foo_test.go:27: output from root test\n"}
+{"Action":"pass","Test":"TestOutputWithSubtest/sub_test/sub2"}
+{"Action":"pass","Test":"TestOutputWithSubtest/sub_test"}
+{"Action":"output","Test":"TestOutputWithSubtest/sub_test2","Output":"    --- PASS: TestOutputWithSubtest/sub_test2 (0.00s)\n"}
+{"Action":"output","Test":"TestOutputWithSubtest/sub_test2","Output":"        foo_test.go:21: output from sub test2\n"}
+{"Action":"output","Test":"TestOutputWithSubtest/sub_test2","Output":"        foo_test.go:23: more output from sub test2\n"}
+{"Action":"output","Test":"TestOutputWithSubtest/sub_test2","Output":"        foo_test.go:28: more output from sub test2\n"}
+{"Action":"output","Test":"TestOutputWithSubtest/sub_test2/sub2","Output":"        --- PASS: TestOutputWithSubtest/sub_test2/sub2 (0.00s)\n"}
+{"Action":"output","Test":"TestOutputWithSubtest/sub_test2/sub2","Output":"            foo_test.go:26: output from sub2 test\n"}
+{"Action":"output","Test":"TestOutputWithSubtest/sub_test2/sub2","Output":"    foo_test.go:32: output after sub test\n"}
+{"Action":"pass","Test":"TestOutputWithSubtest/sub_test2/sub2"}
+{"Action":"pass","Test":"TestOutputWithSubtest/sub_test2"}
+{"Action":"fail","Test":"TestOutputWithSubtest"}
+{"Action":"output","Output":"FAIL\n"}
+{"Action":"output","Output":"FAIL\tgotest.tools/gotestsum/foo\t0.001s\n"}
+{"Action":"output","Output":"FAIL\n"}
+{"Action":"fail"}

--- a/testjson/testdata/summary-misattributed-output
+++ b/testjson/testdata/summary-misattributed-output
@@ -1,0 +1,21 @@
+
+=== Failed
+=== FAIL:  TestOutputWithSubtest (0.00s)
+    --- PASS: TestOutputWithSubtest/sub_test (0.00s)
+        foo_test.go:9: output from sub test
+        foo_test.go:11: more output from sub test
+        foo_test.go:16: more output from sub test
+        --- PASS: TestOutputWithSubtest/sub_test/sub2 (0.00s)
+            foo_test.go:14: output from sub2 test
+    foo_test.go:22: output from root test
+    foo_test.go:27: output from root test
+    --- PASS: TestOutputWithSubtest/sub_test2 (0.00s)
+        foo_test.go:21: output from sub test2
+        foo_test.go:23: more output from sub test2
+        foo_test.go:28: more output from sub test2
+        --- PASS: TestOutputWithSubtest/sub_test2/sub2 (0.00s)
+            foo_test.go:26: output from sub2 test
+    foo_test.go:32: output after sub test
+
+
+DONE 5 tests, 1 failure in 0.000s

--- a/testjson/testdata/summary-root-test-has-subtest-failures
+++ b/testjson/testdata/summary-root-test-has-subtest-failures
@@ -1,0 +1,35 @@
+
+=== Skipped
+=== SKIP: github.com/gotestyourself/gotestyourself/testjson/internal/good TestSkipped (0.00s)
+	good_test.go:23: 
+
+=== SKIP: github.com/gotestyourself/gotestyourself/testjson/internal/good TestSkippedWitLog (0.00s)
+	good_test.go:27: the skip message
+
+=== SKIP: github.com/gotestyourself/gotestyourself/testjson/internal/stub TestSkipped (0.00s)
+	stub_test.go:26: 
+
+=== SKIP: github.com/gotestyourself/gotestyourself/testjson/internal/stub TestSkippedWitLog (0.00s)
+	stub_test.go:30: the skip message
+
+
+=== Failed
+=== FAIL: github.com/gotestyourself/gotestyourself/testjson/internal/badmain  (0.00s)
+sometimes main can exit 2
+FAIL	github.com/gotestyourself/gotestyourself/testjson/internal/badmain	0.010s
+
+=== FAIL: github.com/gotestyourself/gotestyourself/testjson/internal/stub TestFailed (0.00s)
+	stub_test.go:34: this failed
+
+=== FAIL: github.com/gotestyourself/gotestyourself/testjson/internal/stub TestFailedWithStderr (0.00s)
+this is stderr
+	stub_test.go:43: also failed
+
+=== FAIL: github.com/gotestyourself/gotestyourself/testjson/internal/stub TestNestedWithFailure/c (0.00s)
+    --- FAIL: TestNestedWithFailure/c (0.00s)
+    	stub_test.go:65: failed
+
+=== FAIL: github.com/gotestyourself/gotestyourself/testjson/internal/stub TestNestedWithFailure (0.00s)
+
+
+DONE 46 tests, 4 skipped, 5 failures in 0.000s


### PR DESCRIPTION
See golang/go#29755, which may be fixed by https://github.com/golang/go/pull/34419 if that is merged. Even if that fix makes it into go1.15 there will be plenty of projects still running earlier versions of Go, so a workaround may be useful for another year or more.

Related to #64, #66

If a test fails, and there is no test output (other than framing), then print all the test output for the entire test case.

This won't fix the issue if the test which failed had some output, but well behaved tests generally shouldn't non-failure message output, so hopefully this case is rare.