### PR TITLE
Use an explicit list of linters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ workflows:
                 git config --global core.symlinks true
 
       - go/lint:
-          golangci-lint-version: 1.21.0
+          golangci-lint-version: 1.24.0
 
       - build
       - run

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,20 +6,6 @@ linters-settings:
     min-occurrences: 4
   lll:
     line-length: 120
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - performance
-      - style
-      - experimental
-    disabled-checks:
-      - importShadow
-      - paramTypeCombine
-      - commentFormatting # https://github.com/go-critic/go-critic/issues/755
-      - unnamedResult
-    settings:
-      hugeParam:
-        sizeThreshold: 256
 
 issues:
   exclude-use-default: false
@@ -29,14 +15,32 @@ issues:
     - 'always receives'
 
 linters:
-  enable-all: true
-  disable:
-    - dupl
-    - gochecknoglobals
-    - gochecknoinits
-    - gosec
-    - scopelint
-    - maligned
-    - godox
-    - wsl
-    - funlen
+  disable-all: true
+  enable:
+    - bodyclose
+    - deadcode
+    - depguard
+    - errcheck
+    - gocognit
+    - goconst
+    - gocyclo
+    - gofmt
+    - goimports
+    - golint
+    - gosimple
+    - govet
+    - ineffassign
+    - interfacer
+    - lll
+    - misspell
+    - nakedret
+    - prealloc
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace


### PR DESCRIPTION
Instead of an exclude list. This way the addition of new linters in golangci-lint does not cause errors.