### PR TITLE
Tests can have more than 2 framing lines

### DIFF
--- a/testjson/execution.go
+++ b/testjson/execution.go
@@ -119,7 +119,6 @@ func (p Package) Output(test string) string {
 // OutputLines returns the full test output for a test as a slice of strings.
 //
 // As a workaround for test output being attributed to the wrong subtest, if:
-//   - the requested test output only contains framing lines (ex: --- FAIL: ), and
 //   - the TestCase is a root TestCase (not a subtest), and
 //   - the TestCase has no subtest failures;
 // then all output for every subtest under the root test is returned.
@@ -127,10 +126,6 @@ func (p Package) Output(test string) string {
 func (p Package) OutputLines(tc TestCase) []string {
 	root, sub := splitTestName(tc.Test)
 	lines := p.output[root][sub]
-	// every test will have 2 framing lines, === RUN, and --- {PASS,FAIL}
-	if len(lines) > 2 {
-		return lines
-	}
 
 	// If this is a subtest, or a root test case with subtest failures the
 	// subtest failure output should contain the relevant lines, so we don't need

--- a/testjson/summary.go
+++ b/testjson/summary.go
@@ -112,7 +112,7 @@ func formatExecStatus(done bool) string {
 // FormatDurationAsSeconds formats a time.Duration as a float with an s suffix.
 func FormatDurationAsSeconds(d time.Duration, precision int) string {
 	if d == neverFinished {
-		return "panic"
+		return "unknown"
 	}
 	return fmt.Sprintf("%.[2]*[1]fs", d.Seconds(), precision)
 }

--- a/testjson/testdata/summary-missing-test-fail-event
+++ b/testjson/testdata/summary-missing-test-fail-event
@@ -1,6 +1,6 @@
 
 === Failed
-=== FAIL: gotest.tools/v3/poll TestWaitOn_WithCompare (panic)
+=== FAIL: gotest.tools/v3/poll TestWaitOn_WithCompare (unknown)
 panic: runtime error: index out of range [1] with length 1
 
 goroutine 7 [running]:


### PR DESCRIPTION
Pause and continue lines may be in the output. The other conditions in this function should be correct on their own for determining if additional lines need to be returned.