### PR TITLE
Add a pre-commit hook configuration

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,9 @@
+- id: gotestsum
+  name: gotestsum
+  description: |
+    `go test` runner with output optimized for humans, JUnit XML for CI
+    integration, and a summary of the test results.
+  entry: gotestsum
+  types: [go]
+  language: golang
+  pass_filenames: false


### PR DESCRIPTION
This enables using gotestsum as a pre-commit hook via the https://pre-commit.com/ framework.