### PR TITLE
Better docs for testjson package

### DIFF
--- a/cmd/tool/slowest/slowest.go
+++ b/cmd/tool/slowest/slowest.go
@@ -1,7 +1,6 @@
 package slowest
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -104,10 +103,7 @@ func run(opts *options) error {
 		}
 	}()
 
-	exec, err := testjson.ScanTestOutput(testjson.ScanConfig{
-		Stdout: in,
-		Stderr: bytes.NewReader(nil),
-	})
+	exec, err := testjson.ScanTestOutput(testjson.ScanConfig{Stdout: in})
 	if err != nil {
 		return fmt.Errorf("failed to scan testjson: %v", err)
 	}

--- a/do
+++ b/do
@@ -59,4 +59,12 @@ _docker-build-dev() {
     cat "$idfile"
 }
 
+help[godoc]="Run godoc locally to preview package documentation."
+godoc() {
+    local url; url="http://localhost:6060/pkg/$(go list)/"
+    command -v xdg-open && xdg-open "$url" &
+    command -v open && open "$url" &
+    command godoc -http=:6060
+}
+
 _plsdo_run "$@"

--- a/handler.go
+++ b/handler.go
@@ -19,8 +19,9 @@ type eventHandler struct {
 }
 
 func (h *eventHandler) Err(text string) error {
-	_, err := h.err.Write([]byte(text + "\n"))
-	return err
+	_, _ = h.err.Write([]byte(text + "\n"))
+	// always return nil, no need to stop scanning if the stderr write fails
+	return nil
 }
 
 func (h *eventHandler) Event(event testjson.TestEvent, execution *testjson.Execution) error {

--- a/testjson/doc.go
+++ b/testjson/doc.go
@@ -1,4 +1,17 @@
 /*Package testjson scans test2json output and builds up a summary of the events.
 Events are passed to a formatter for output.
+
+Example
+
+This example reads the test2json output from os.Stdin. It builds an
+Execution from the output, then it prints the number of tests run.
+
+
+    exec, err := testjson.ScanTestOutput(testjson.ScanConfig{Stdout: os.Stdin})
+    if err != nil {
+        return fmt.Errorf("failed to scan testjson: %v", err)
+    }
+    fmt.Println("Ran %d tests", exec.Total())
+
 */
 package testjson // import "gotest.tools/gotestsum/testjson"

--- a/testjson/execution_test.go
+++ b/testjson/execution_test.go
@@ -1,11 +1,13 @@
 package testjson
 
 import (
+	"bytes"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/golden"
 )
 
 func TestPackage_Elapsed(t *testing.T) {
@@ -25,7 +27,7 @@ func TestPackage_Elapsed(t *testing.T) {
 }
 
 func TestExecution_Add_PackageCoverage(t *testing.T) {
-	exec := NewExecution()
+	exec := newExecution()
 	exec.add(TestEvent{
 		Package: "mytestpkg",
 		Action:  ActionOutput,
@@ -46,3 +48,11 @@ func TestExecution_Add_PackageCoverage(t *testing.T) {
 }
 
 var cmpPackage = cmp.AllowUnexported(Package{})
+
+func TestScanTestOutput_MinimalConfig(t *testing.T) {
+	in := bytes.NewReader(golden.Get(t, "go-test-json.out"))
+	exec, err := ScanTestOutput(ScanConfig{Stdout: in})
+	assert.NilError(t, err)
+	// a weak check to show that all the stdout was scanned
+	assert.Equal(t, exec.Total(), 46)
+}


### PR DESCRIPTION
Also make ScanTestOutput easier to use.

Adds `godoc` to project tasks for previewing doc changes.