### PR TITLE
Update pflag to remove the -test.x flag dropping

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module gotest.tools/gotestsum
 
+replace github.com/spf13/pflag => github.com/dnephin/pflag v0.0.0-20200521001137-0f09ccd3add8
+
 require (
 	github.com/fatih/color v1.9.0
 	github.com/google/go-cmp v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/dnephin/pflag v0.0.0-20200521001137-0f09ccd3add8 h1:7JFEKdSKf4LLYMqIMxjwffbi7sdmW+SQU9Ec2vETFHs=
+github.com/dnephin/pflag v0.0.0-20200521001137-0f09ccd3add8/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
@@ -18,8 +20,6 @@ github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
-github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a h1:oWX7TPOiFAMXLq8o0ikBYfCJVlRHBcsciT5bXOrH628=


### PR DESCRIPTION
https://github.com/spf13/pflag/pull/259

The old behaviour could be confusing because the `-test.x` flags never got through to the go binary. 