### PR TITLE
bug fixes for rerun fails

### DIFF
--- a/do
+++ b/do
@@ -8,6 +8,11 @@ binary() {
 }
 
 update-golden() {
+    _update-golden
+    GOLANG_VERSION=1.13-alpine ./do shell bash -c 'go build; PATH=$PATH:. ./do _update-golden'
+}
+
+_update-golden() {
     gotestsum -- . ./testjson ./internal/junitxml ./cmd/tool/slowest -test.update-golden
 }
 

--- a/flags.go
+++ b/flags.go
@@ -117,7 +117,7 @@ func (c *commandValue) Value() []string {
 var _ pflag.Value = (*stringSlice)(nil)
 
 // stringSlice is a flag.Value which populates the string slice by splitting
-// the raw flag value on spaces.
+// the raw flag value on whitespace.
 type stringSlice []string
 
 func (s *stringSlice) String() string {
@@ -125,7 +125,7 @@ func (s *stringSlice) String() string {
 }
 
 func (s *stringSlice) Set(raw string) error {
-	*s = append(*s, strings.Split(raw, " ")...)
+	*s = append(*s, strings.Fields(raw)...)
 	return nil
 }
 

--- a/flags_test.go
+++ b/flags_test.go
@@ -25,3 +25,11 @@ func TestNoSummaryValue_SetAndString(t *testing.T) {
 		assert.ErrorContains(t, value.Set("bogus"), "must be one or more of")
 	})
 }
+
+func TestStringSlice(t *testing.T) {
+	value := "one \ntwo  three\n\tfour\t five   \n"
+	var v []string
+	ss := (*stringSlice)(&v)
+	assert.NilError(t, ss.Set(value))
+	assert.DeepEqual(t, v, []string{"one", "two", "three", "four", "five"})
+}

--- a/main.go
+++ b/main.go
@@ -210,7 +210,7 @@ func run(opts *options) error {
 		return err
 	}
 	goTestExitErr := goTestProc.cmd.Wait()
-	if opts.rerunFailsMaxAttempts > 0 {
+	if goTestExitErr != nil && opts.rerunFailsMaxAttempts > 0 {
 		cfg := testjson.ScanConfig{Execution: exec, Handler: handler}
 		goTestExitErr = rerunFailed(ctx, opts, cfg)
 	}

--- a/testdata/e2e/expected/TestE2E_RerunFails/first_run_has_errors,_abort_rerun
+++ b/testdata/e2e/expected/TestE2E_RerunFails/first_run_has_errors,_abort_rerun
@@ -1,0 +1,5 @@
+
+=== Errors
+testjson/internal/broken/broken.go:5:21: undefined: somepackage
+
+DONE 0 tests, 1 error

--- a/testdata/e2e/expected/TestE2E_RerunFails/first_run_has_errors,_abort_rerun-go1.14
+++ b/testdata/e2e/expected/TestE2E_RerunFails/first_run_has_errors,_abort_rerun-go1.14
@@ -1,0 +1,5 @@
+
+=== Errors
+testjson/internal/broken/broken.go:5:21: undefined: somepackage
+
+DONE 0 tests, 1 error

--- a/testdata/e2e/expected/TestE2E_RerunFails/reruns_continues_to_fail
+++ b/testdata/e2e/expected/TestE2E_RerunFails/reruns_continues_to_fail
@@ -17,6 +17,9 @@ FAIL testdata/e2e/flaky.TestFailsOften
 PASS testdata/e2e/flaky.TestFailsOftenDoesNotPrefixMatch
 PASS testdata/e2e/flaky.TestFailsSometimesDoesNotPrefixMatch
 FAIL testdata/e2e/flaky
+
+DONE 6 tests, 3 failures
+
 PASS testdata/e2e/flaky.TestFailsRarely
 === RUN   TestFailsSometimes
 SEED:  1
@@ -29,6 +32,9 @@ SEED:  1
     flaky_test.go:65: not this time
 FAIL testdata/e2e/flaky.TestFailsOften
 FAIL testdata/e2e/flaky
+
+DONE 9 tests, 5 failures
+
 PASS testdata/e2e/flaky.TestFailsSometimes
 === RUN   TestFailsOften
 SEED:  2

--- a/testdata/e2e/expected/TestE2E_RerunFails/reruns_continues_to_fail-go1.14
+++ b/testdata/e2e/expected/TestE2E_RerunFails/reruns_continues_to_fail-go1.14
@@ -17,6 +17,9 @@ FAIL testdata/e2e/flaky.TestFailsOften
 PASS testdata/e2e/flaky.TestFailsOftenDoesNotPrefixMatch
 PASS testdata/e2e/flaky.TestFailsSometimesDoesNotPrefixMatch
 FAIL testdata/e2e/flaky
+
+DONE 6 tests, 3 failures
+
 PASS testdata/e2e/flaky.TestFailsRarely
 === RUN   TestFailsSometimes
 SEED:  1
@@ -29,6 +32,9 @@ SEED:  1
 --- FAIL: TestFailsOften
 FAIL testdata/e2e/flaky.TestFailsOften
 FAIL testdata/e2e/flaky
+
+DONE 9 tests, 5 failures
+
 PASS testdata/e2e/flaky.TestFailsSometimes
 === RUN   TestFailsOften
 SEED:  2

--- a/testdata/e2e/expected/TestE2E_RerunFails/reruns_until_success
+++ b/testdata/e2e/expected/TestE2E_RerunFails/reruns_until_success
@@ -17,6 +17,9 @@ FAIL testdata/e2e/flaky.TestFailsOften
 PASS testdata/e2e/flaky.TestFailsOftenDoesNotPrefixMatch
 PASS testdata/e2e/flaky.TestFailsSometimesDoesNotPrefixMatch
 FAIL testdata/e2e/flaky
+
+DONE 6 tests, 3 failures
+
 PASS testdata/e2e/flaky.TestFailsRarely
 === RUN   TestFailsSometimes
 SEED:  1
@@ -29,6 +32,9 @@ SEED:  1
     flaky_test.go:65: not this time
 FAIL testdata/e2e/flaky.TestFailsOften
 FAIL testdata/e2e/flaky
+
+DONE 9 tests, 5 failures
+
 PASS testdata/e2e/flaky.TestFailsSometimes
 === RUN   TestFailsOften
 SEED:  2
@@ -36,12 +42,18 @@ SEED:  2
     flaky_test.go:65: not this time
 FAIL testdata/e2e/flaky.TestFailsOften
 FAIL testdata/e2e/flaky
+
+DONE 11 tests, 6 failures
+
 === RUN   TestFailsOften
 SEED:  3
 --- FAIL: TestFailsOften
     flaky_test.go:65: not this time
 FAIL testdata/e2e/flaky.TestFailsOften
 FAIL testdata/e2e/flaky
+
+DONE 12 tests, 7 failures
+
 PASS testdata/e2e/flaky.TestFailsOften
 PASS testdata/e2e/flaky
 

--- a/testdata/e2e/expected/TestE2E_RerunFails/reruns_until_success-go1.14
+++ b/testdata/e2e/expected/TestE2E_RerunFails/reruns_until_success-go1.14
@@ -17,6 +17,9 @@ FAIL testdata/e2e/flaky.TestFailsOften
 PASS testdata/e2e/flaky.TestFailsOftenDoesNotPrefixMatch
 PASS testdata/e2e/flaky.TestFailsSometimesDoesNotPrefixMatch
 FAIL testdata/e2e/flaky
+
+DONE 6 tests, 3 failures
+
 PASS testdata/e2e/flaky.TestFailsRarely
 === RUN   TestFailsSometimes
 SEED:  1
@@ -29,6 +32,9 @@ SEED:  1
 --- FAIL: TestFailsOften
 FAIL testdata/e2e/flaky.TestFailsOften
 FAIL testdata/e2e/flaky
+
+DONE 9 tests, 5 failures
+
 PASS testdata/e2e/flaky.TestFailsSometimes
 === RUN   TestFailsOften
 SEED:  2
@@ -36,12 +42,18 @@ SEED:  2
 --- FAIL: TestFailsOften
 FAIL testdata/e2e/flaky.TestFailsOften
 FAIL testdata/e2e/flaky
+
+DONE 11 tests, 6 failures
+
 === RUN   TestFailsOften
 SEED:  3
     TestFailsOften: flaky_test.go:65: not this time
 --- FAIL: TestFailsOften
 FAIL testdata/e2e/flaky.TestFailsOften
 FAIL testdata/e2e/flaky
+
+DONE 12 tests, 7 failures
+
 PASS testdata/e2e/flaky.TestFailsOften
 PASS testdata/e2e/flaky
 


### PR DESCRIPTION
* add a `DONE` line after each attempt
* abort the rerun if any run has errors
* warn if `go test` exits with any code other than 0 or 1
* `./do update-golden` runs go1.13 in a container to update both sets of golden files
* some misc improvements to naming