### PR TITLE
Add re-run number to testname format, and summary

### DIFF
--- a/main.go
+++ b/main.go
@@ -210,9 +210,13 @@ func run(opts *options) error {
 		return err
 	}
 	goTestExitErr := goTestProc.cmd.Wait()
+
 	if goTestExitErr != nil && opts.rerunFailsMaxAttempts > 0 {
-		cfg := testjson.ScanConfig{Execution: exec, Handler: handler}
-		goTestExitErr = rerunFailed(ctx, opts, cfg)
+		goTestExitErr = hasErrors(goTestExitErr, exec)
+		if goTestExitErr == nil {
+			cfg := testjson.ScanConfig{Execution: exec, Handler: handler}
+			goTestExitErr = rerunFailed(ctx, opts, cfg)
+		}
 	}
 
 	testjson.PrintSummary(opts.stdout, exec, opts.noSummary.value)

--- a/rerunfails.go
+++ b/rerunfails.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"gotest.tools/gotestsum/log"
 	"gotest.tools/gotestsum/testjson"
 )
 
@@ -32,9 +31,6 @@ func rerunFailed(ctx context.Context, opts *options, scanConfig testjson.ScanCon
 		return fmt.Errorf(
 			"number of test failures (%d) exceeds maximum (%d) set by --rerun-fails-max-failures",
 			failed, opts.rerunFailsMaxInitialFailures)
-	}
-	if err := hasErrors(scanConfig.Execution); err != nil {
-		return err
 	}
 
 	rec := newFailureRecorderFromExecution(scanConfig.Execution)
@@ -64,12 +60,7 @@ func rerunFailed(ctx context.Context, opts *options, scanConfig testjson.ScanCon
 				return err
 			}
 			lastErr = goTestProc.cmd.Wait()
-			// 0 and 1 are expected.
-			if ExitCodeWithDefault(lastErr) > 1 {
-				log.Warnf("unexpected go test exit code: %v", lastErr)
-				// TODO: will 'go test' exit with 2 if it panics? maybe return err here.
-			}
-			if err := hasErrors(scanConfig.Execution); err != nil {
+			if err := hasErrors(lastErr, scanConfig.Execution); err != nil {
 				return err
 			}
 			rec = nextRec
@@ -78,11 +69,16 @@ func rerunFailed(ctx context.Context, opts *options, scanConfig testjson.ScanCon
 	return lastErr
 }
 
-func hasErrors(exec *testjson.Execution) error {
-	if len(exec.Errors()) > 0 {
+func hasErrors(err error, exec *testjson.Execution) error {
+	switch {
+	case len(exec.Errors()) > 0:
 		return fmt.Errorf("rerun aborted because previous run had errors")
+	// Exit code 0 and 1 are expected.
+	case ExitCodeWithDefault(err) > 1:
+		return fmt.Errorf("unexpected go test exit code: %v", err)
+	default:
+		return nil
 	}
-	return nil
 }
 
 type failureRecorder struct {

--- a/rerunfails.go
+++ b/rerunfails.go
@@ -51,6 +51,7 @@ func rerunFailed(ctx context.Context, opts *options, scanConfig testjson.ScanCon
 			}
 
 			cfg := testjson.ScanConfig{
+				RunID:     attempts + 1,
 				Stdout:    goTestProc.stdout,
 				Stderr:    goTestProc.stderr,
 				Handler:   nextRec,

--- a/testdata/e2e/expected/TestE2E_RerunFails/reruns_continues_to_fail
+++ b/testdata/e2e/expected/TestE2E_RerunFails/reruns_continues_to_fail
@@ -33,7 +33,7 @@ SEED:  1
 FAIL testdata/e2e/flaky.TestFailsOften (re-run 1)
 FAIL testdata/e2e/flaky
 
-DONE 9 tests, 5 failures
+DONE 2 runs, 9 tests, 5 failures
 
 PASS testdata/e2e/flaky.TestFailsSometimes (re-run 2)
 === RUN   TestFailsOften
@@ -69,4 +69,4 @@ SEED:  2
     flaky_test.go:65: not this time
 
 
-DONE 11 tests, 6 failures
+DONE 3 runs, 11 tests, 6 failures

--- a/testdata/e2e/expected/TestE2E_RerunFails/reruns_continues_to_fail
+++ b/testdata/e2e/expected/TestE2E_RerunFails/reruns_continues_to_fail
@@ -20,27 +20,27 @@ FAIL testdata/e2e/flaky
 
 DONE 6 tests, 3 failures
 
-PASS testdata/e2e/flaky.TestFailsRarely
+PASS testdata/e2e/flaky.TestFailsRarely (re-run 1)
 === RUN   TestFailsSometimes
 SEED:  1
 --- FAIL: TestFailsSometimes
     flaky_test.go:58: not this time
-FAIL testdata/e2e/flaky.TestFailsSometimes
+FAIL testdata/e2e/flaky.TestFailsSometimes (re-run 1)
 === RUN   TestFailsOften
 SEED:  1
 --- FAIL: TestFailsOften
     flaky_test.go:65: not this time
-FAIL testdata/e2e/flaky.TestFailsOften
+FAIL testdata/e2e/flaky.TestFailsOften (re-run 1)
 FAIL testdata/e2e/flaky
 
 DONE 9 tests, 5 failures
 
-PASS testdata/e2e/flaky.TestFailsSometimes
+PASS testdata/e2e/flaky.TestFailsSometimes (re-run 2)
 === RUN   TestFailsOften
 SEED:  2
 --- FAIL: TestFailsOften
     flaky_test.go:65: not this time
-FAIL testdata/e2e/flaky.TestFailsOften
+FAIL testdata/e2e/flaky.TestFailsOften (re-run 2)
 FAIL testdata/e2e/flaky
 
 === Failed
@@ -56,15 +56,15 @@ SEED:  0
 SEED:  0
     flaky_test.go:65: not this time
 
-=== FAIL: testdata/e2e/flaky TestFailsSometimes
+=== FAIL: testdata/e2e/flaky TestFailsSometimes (re-run 1)
 SEED:  1
     flaky_test.go:58: not this time
 
-=== FAIL: testdata/e2e/flaky TestFailsOften
+=== FAIL: testdata/e2e/flaky TestFailsOften (re-run 1)
 SEED:  1
     flaky_test.go:65: not this time
 
-=== FAIL: testdata/e2e/flaky TestFailsOften
+=== FAIL: testdata/e2e/flaky TestFailsOften (re-run 2)
 SEED:  2
     flaky_test.go:65: not this time
 

--- a/testdata/e2e/expected/TestE2E_RerunFails/reruns_continues_to_fail-go1.14
+++ b/testdata/e2e/expected/TestE2E_RerunFails/reruns_continues_to_fail-go1.14
@@ -33,7 +33,7 @@ SEED:  1
 FAIL testdata/e2e/flaky.TestFailsOften (re-run 1)
 FAIL testdata/e2e/flaky
 
-DONE 9 tests, 5 failures
+DONE 2 runs, 9 tests, 5 failures
 
 PASS testdata/e2e/flaky.TestFailsSometimes (re-run 2)
 === RUN   TestFailsOften
@@ -69,4 +69,4 @@ SEED:  2
     TestFailsOften: flaky_test.go:65: not this time
 
 
-DONE 11 tests, 6 failures
+DONE 3 runs, 11 tests, 6 failures

--- a/testdata/e2e/expected/TestE2E_RerunFails/reruns_continues_to_fail-go1.14
+++ b/testdata/e2e/expected/TestE2E_RerunFails/reruns_continues_to_fail-go1.14
@@ -20,27 +20,27 @@ FAIL testdata/e2e/flaky
 
 DONE 6 tests, 3 failures
 
-PASS testdata/e2e/flaky.TestFailsRarely
+PASS testdata/e2e/flaky.TestFailsRarely (re-run 1)
 === RUN   TestFailsSometimes
 SEED:  1
     TestFailsSometimes: flaky_test.go:58: not this time
 --- FAIL: TestFailsSometimes
-FAIL testdata/e2e/flaky.TestFailsSometimes
+FAIL testdata/e2e/flaky.TestFailsSometimes (re-run 1)
 === RUN   TestFailsOften
 SEED:  1
     TestFailsOften: flaky_test.go:65: not this time
 --- FAIL: TestFailsOften
-FAIL testdata/e2e/flaky.TestFailsOften
+FAIL testdata/e2e/flaky.TestFailsOften (re-run 1)
 FAIL testdata/e2e/flaky
 
 DONE 9 tests, 5 failures
 
-PASS testdata/e2e/flaky.TestFailsSometimes
+PASS testdata/e2e/flaky.TestFailsSometimes (re-run 2)
 === RUN   TestFailsOften
 SEED:  2
     TestFailsOften: flaky_test.go:65: not this time
 --- FAIL: TestFailsOften
-FAIL testdata/e2e/flaky.TestFailsOften
+FAIL testdata/e2e/flaky.TestFailsOften (re-run 2)
 FAIL testdata/e2e/flaky
 
 === Failed
@@ -56,15 +56,15 @@ SEED:  0
 SEED:  0
     TestFailsOften: flaky_test.go:65: not this time
 
-=== FAIL: testdata/e2e/flaky TestFailsSometimes
+=== FAIL: testdata/e2e/flaky TestFailsSometimes (re-run 1)
 SEED:  1
     TestFailsSometimes: flaky_test.go:58: not this time
 
-=== FAIL: testdata/e2e/flaky TestFailsOften
+=== FAIL: testdata/e2e/flaky TestFailsOften (re-run 1)
 SEED:  1
     TestFailsOften: flaky_test.go:65: not this time
 
-=== FAIL: testdata/e2e/flaky TestFailsOften
+=== FAIL: testdata/e2e/flaky TestFailsOften (re-run 2)
 SEED:  2
     TestFailsOften: flaky_test.go:65: not this time
 

--- a/testdata/e2e/expected/TestE2E_RerunFails/reruns_until_success
+++ b/testdata/e2e/expected/TestE2E_RerunFails/reruns_until_success
@@ -20,27 +20,27 @@ FAIL testdata/e2e/flaky
 
 DONE 6 tests, 3 failures
 
-PASS testdata/e2e/flaky.TestFailsRarely
+PASS testdata/e2e/flaky.TestFailsRarely (re-run 1)
 === RUN   TestFailsSometimes
 SEED:  1
 --- FAIL: TestFailsSometimes
     flaky_test.go:58: not this time
-FAIL testdata/e2e/flaky.TestFailsSometimes
+FAIL testdata/e2e/flaky.TestFailsSometimes (re-run 1)
 === RUN   TestFailsOften
 SEED:  1
 --- FAIL: TestFailsOften
     flaky_test.go:65: not this time
-FAIL testdata/e2e/flaky.TestFailsOften
+FAIL testdata/e2e/flaky.TestFailsOften (re-run 1)
 FAIL testdata/e2e/flaky
 
 DONE 9 tests, 5 failures
 
-PASS testdata/e2e/flaky.TestFailsSometimes
+PASS testdata/e2e/flaky.TestFailsSometimes (re-run 2)
 === RUN   TestFailsOften
 SEED:  2
 --- FAIL: TestFailsOften
     flaky_test.go:65: not this time
-FAIL testdata/e2e/flaky.TestFailsOften
+FAIL testdata/e2e/flaky.TestFailsOften (re-run 2)
 FAIL testdata/e2e/flaky
 
 DONE 11 tests, 6 failures
@@ -49,12 +49,12 @@ DONE 11 tests, 6 failures
 SEED:  3
 --- FAIL: TestFailsOften
     flaky_test.go:65: not this time
-FAIL testdata/e2e/flaky.TestFailsOften
+FAIL testdata/e2e/flaky.TestFailsOften (re-run 3)
 FAIL testdata/e2e/flaky
 
 DONE 12 tests, 7 failures
 
-PASS testdata/e2e/flaky.TestFailsOften
+PASS testdata/e2e/flaky.TestFailsOften (re-run 4)
 PASS testdata/e2e/flaky
 
 === Failed
@@ -70,19 +70,19 @@ SEED:  0
 SEED:  0
     flaky_test.go:65: not this time
 
-=== FAIL: testdata/e2e/flaky TestFailsSometimes
+=== FAIL: testdata/e2e/flaky TestFailsSometimes (re-run 1)
 SEED:  1
     flaky_test.go:58: not this time
 
-=== FAIL: testdata/e2e/flaky TestFailsOften
+=== FAIL: testdata/e2e/flaky TestFailsOften (re-run 1)
 SEED:  1
     flaky_test.go:65: not this time
 
-=== FAIL: testdata/e2e/flaky TestFailsOften
+=== FAIL: testdata/e2e/flaky TestFailsOften (re-run 2)
 SEED:  2
     flaky_test.go:65: not this time
 
-=== FAIL: testdata/e2e/flaky TestFailsOften
+=== FAIL: testdata/e2e/flaky TestFailsOften (re-run 3)
 SEED:  3
     flaky_test.go:65: not this time
 

--- a/testdata/e2e/expected/TestE2E_RerunFails/reruns_until_success
+++ b/testdata/e2e/expected/TestE2E_RerunFails/reruns_until_success
@@ -33,7 +33,7 @@ SEED:  1
 FAIL testdata/e2e/flaky.TestFailsOften (re-run 1)
 FAIL testdata/e2e/flaky
 
-DONE 9 tests, 5 failures
+DONE 2 runs, 9 tests, 5 failures
 
 PASS testdata/e2e/flaky.TestFailsSometimes (re-run 2)
 === RUN   TestFailsOften
@@ -43,7 +43,7 @@ SEED:  2
 FAIL testdata/e2e/flaky.TestFailsOften (re-run 2)
 FAIL testdata/e2e/flaky
 
-DONE 11 tests, 6 failures
+DONE 3 runs, 11 tests, 6 failures
 
 === RUN   TestFailsOften
 SEED:  3
@@ -52,7 +52,7 @@ SEED:  3
 FAIL testdata/e2e/flaky.TestFailsOften (re-run 3)
 FAIL testdata/e2e/flaky
 
-DONE 12 tests, 7 failures
+DONE 4 runs, 12 tests, 7 failures
 
 PASS testdata/e2e/flaky.TestFailsOften (re-run 4)
 PASS testdata/e2e/flaky
@@ -87,4 +87,4 @@ SEED:  3
     flaky_test.go:65: not this time
 
 
-DONE 13 tests, 7 failures
+DONE 5 runs, 13 tests, 7 failures

--- a/testdata/e2e/expected/TestE2E_RerunFails/reruns_until_success-go1.14
+++ b/testdata/e2e/expected/TestE2E_RerunFails/reruns_until_success-go1.14
@@ -20,27 +20,27 @@ FAIL testdata/e2e/flaky
 
 DONE 6 tests, 3 failures
 
-PASS testdata/e2e/flaky.TestFailsRarely
+PASS testdata/e2e/flaky.TestFailsRarely (re-run 1)
 === RUN   TestFailsSometimes
 SEED:  1
     TestFailsSometimes: flaky_test.go:58: not this time
 --- FAIL: TestFailsSometimes
-FAIL testdata/e2e/flaky.TestFailsSometimes
+FAIL testdata/e2e/flaky.TestFailsSometimes (re-run 1)
 === RUN   TestFailsOften
 SEED:  1
     TestFailsOften: flaky_test.go:65: not this time
 --- FAIL: TestFailsOften
-FAIL testdata/e2e/flaky.TestFailsOften
+FAIL testdata/e2e/flaky.TestFailsOften (re-run 1)
 FAIL testdata/e2e/flaky
 
 DONE 9 tests, 5 failures
 
-PASS testdata/e2e/flaky.TestFailsSometimes
+PASS testdata/e2e/flaky.TestFailsSometimes (re-run 2)
 === RUN   TestFailsOften
 SEED:  2
     TestFailsOften: flaky_test.go:65: not this time
 --- FAIL: TestFailsOften
-FAIL testdata/e2e/flaky.TestFailsOften
+FAIL testdata/e2e/flaky.TestFailsOften (re-run 2)
 FAIL testdata/e2e/flaky
 
 DONE 11 tests, 6 failures
@@ -49,12 +49,12 @@ DONE 11 tests, 6 failures
 SEED:  3
     TestFailsOften: flaky_test.go:65: not this time
 --- FAIL: TestFailsOften
-FAIL testdata/e2e/flaky.TestFailsOften
+FAIL testdata/e2e/flaky.TestFailsOften (re-run 3)
 FAIL testdata/e2e/flaky
 
 DONE 12 tests, 7 failures
 
-PASS testdata/e2e/flaky.TestFailsOften
+PASS testdata/e2e/flaky.TestFailsOften (re-run 4)
 PASS testdata/e2e/flaky
 
 === Failed
@@ -70,19 +70,19 @@ SEED:  0
 SEED:  0
     TestFailsOften: flaky_test.go:65: not this time
 
-=== FAIL: testdata/e2e/flaky TestFailsSometimes
+=== FAIL: testdata/e2e/flaky TestFailsSometimes (re-run 1)
 SEED:  1
     TestFailsSometimes: flaky_test.go:58: not this time
 
-=== FAIL: testdata/e2e/flaky TestFailsOften
+=== FAIL: testdata/e2e/flaky TestFailsOften (re-run 1)
 SEED:  1
     TestFailsOften: flaky_test.go:65: not this time
 
-=== FAIL: testdata/e2e/flaky TestFailsOften
+=== FAIL: testdata/e2e/flaky TestFailsOften (re-run 2)
 SEED:  2
     TestFailsOften: flaky_test.go:65: not this time
 
-=== FAIL: testdata/e2e/flaky TestFailsOften
+=== FAIL: testdata/e2e/flaky TestFailsOften (re-run 3)
 SEED:  3
     TestFailsOften: flaky_test.go:65: not this time
 

--- a/testdata/e2e/expected/TestE2E_RerunFails/reruns_until_success-go1.14
+++ b/testdata/e2e/expected/TestE2E_RerunFails/reruns_until_success-go1.14
@@ -33,7 +33,7 @@ SEED:  1
 FAIL testdata/e2e/flaky.TestFailsOften (re-run 1)
 FAIL testdata/e2e/flaky
 
-DONE 9 tests, 5 failures
+DONE 2 runs, 9 tests, 5 failures
 
 PASS testdata/e2e/flaky.TestFailsSometimes (re-run 2)
 === RUN   TestFailsOften
@@ -43,7 +43,7 @@ SEED:  2
 FAIL testdata/e2e/flaky.TestFailsOften (re-run 2)
 FAIL testdata/e2e/flaky
 
-DONE 11 tests, 6 failures
+DONE 3 runs, 11 tests, 6 failures
 
 === RUN   TestFailsOften
 SEED:  3
@@ -52,7 +52,7 @@ SEED:  3
 FAIL testdata/e2e/flaky.TestFailsOften (re-run 3)
 FAIL testdata/e2e/flaky
 
-DONE 12 tests, 7 failures
+DONE 4 runs, 12 tests, 7 failures
 
 PASS testdata/e2e/flaky.TestFailsOften (re-run 4)
 PASS testdata/e2e/flaky
@@ -87,4 +87,4 @@ SEED:  3
     TestFailsOften: flaky_test.go:65: not this time
 
 
-DONE 13 tests, 7 failures
+DONE 5 runs, 13 tests, 7 failures

--- a/testjson/execution.go
+++ b/testjson/execution.go
@@ -44,6 +44,8 @@ type TestEvent struct {
 	Output string
 	// raw is the raw JSON bytes of the event
 	raw []byte
+	// RunID from the ScanConfig which produced this test event.
+	RunID int
 }
 
 // PackageEvent returns true if the event is a package start or end event
@@ -231,6 +233,8 @@ type TestCase struct {
 	Package string
 	Test    string
 	Elapsed time.Duration
+	// RunID from the ScanConfig which produced this test case.
+	RunID int
 	// hasSubTestFailed is true when a subtest of this TestCase has failed. It is
 	// used to find root TestCases which have no failing subtests.
 	hasSubTestFailed bool
@@ -294,6 +298,7 @@ func (p *Package) addTestEvent(event TestEvent) {
 			Package: event.Package,
 			Test:    event.Test,
 			ID:      p.Total,
+			RunID:   event.RunID,
 		}
 		p.running[event.Test] = tc
 
@@ -460,6 +465,9 @@ func newExecution() *Execution {
 
 // ScanConfig used by ScanTestOutput.
 type ScanConfig struct {
+	// RunID is a unique identifier for the run. It may be set to the pid of the
+	// process, or some other identifier. It will stored as the TestCase.RunID.
+	RunID int
 	// Stdout is a reader that yields the test2json output stream.
 	Stdout io.Reader
 	// Stderr is a reader that yields stderr from the 'go test' process. Often
@@ -533,6 +541,7 @@ func readStdout(config ScanConfig, execution *Execution) error {
 			return errors.Wrapf(err, "failed to parse test output: %s", string(raw))
 		}
 
+		event.RunID = config.RunID
 		execution.add(event)
 		if err := config.Handler.Event(event, execution); err != nil {
 			return err

--- a/testjson/execution.go
+++ b/testjson/execution.go
@@ -250,10 +250,11 @@ func newPackage() *Package {
 
 // Execution of one or more test packages
 type Execution struct {
-	started  time.Time
-	packages map[string]*Package
-	errors   []string
-	done     bool
+	started   time.Time
+	packages  map[string]*Package
+	errors    []string
+	done      bool
+	lastRunID int
 }
 
 func (e *Execution) add(event TestEvent) {
@@ -508,6 +509,9 @@ func ScanTestOutput(config ScanConfig) (*Execution, error) {
 	if execution == nil {
 		execution = newExecution()
 	}
+	execution.done = false
+	execution.lastRunID = config.RunID
+
 	var group errgroup.Group
 	group.Go(func() error {
 		return readStdout(config, execution)

--- a/testjson/format.go
+++ b/testjson/format.go
@@ -41,20 +41,10 @@ func testNameFormat(event TestEvent, exec *Execution) (string, error) {
 	result := colorEvent(event)(strings.ToUpper(string(event.Action)))
 	formatTest := func() string {
 		pkgPath := RelativePackagePath(event.Package)
-		// If the package path isn't the current directory, we add
-		// a period to separate the test name and the package path.
-		// If it is the current directory, we don't show it at all.
-		// This prevents output like ..MyTest when the test
-		// is in the current directory.
-		if pkgPath == "." {
-			pkgPath = ""
-		} else {
-			pkgPath += "."
-		}
-		return fmt.Sprintf("%s %s%s %s\n",
+
+		return fmt.Sprintf("%s %s %s\n",
 			result,
-			pkgPath,
-			event.Test,
+			joinPkgToTestName(pkgPath, event.Test),
 			event.ElapsedFormatted())
 	}
 
@@ -87,6 +77,18 @@ func testNameFormat(event TestEvent, exec *Execution) (string, error) {
 		return formatTest(), nil
 	}
 	return "", nil
+}
+
+// joinPkgToTestName for formatting.
+// If the package path isn't the current directory, we add a period to separate
+// the test name and the package path. If it is the current directory, we don't
+// show it at all. This prevents output like ..MyTest when the test is in the
+// current directory.
+func joinPkgToTestName(pkg string, test string) string {
+	if pkg == "." {
+		return test
+	}
+	return pkg + "." + test
 }
 
 // isPkgFailureOutput returns true if the event is package output, and the output

--- a/testjson/format.go
+++ b/testjson/format.go
@@ -42,9 +42,10 @@ func testNameFormat(event TestEvent, exec *Execution) (string, error) {
 	formatTest := func() string {
 		pkgPath := RelativePackagePath(event.Package)
 
-		return fmt.Sprintf("%s %s %s\n",
+		return fmt.Sprintf("%s %s%s %s\n",
 			result,
 			joinPkgToTestName(pkgPath, event.Test),
+			formatRunID(event.RunID),
 			event.ElapsedFormatted())
 	}
 
@@ -89,6 +90,14 @@ func joinPkgToTestName(pkg string, test string) string {
 		return test
 	}
 	return pkg + "." + test
+}
+
+// formatRunID returns a formatted string of the runID.
+func formatRunID(runID int) string {
+	if runID <= 0 {
+		return ""
+	}
+	return fmt.Sprintf(" (re-run %d)", runID)
 }
 
 // isPkgFailureOutput returns true if the event is package output, and the output

--- a/testjson/format.go
+++ b/testjson/format.go
@@ -37,7 +37,7 @@ func standardQuietFormat(event TestEvent, _ *Execution) (string, error) {
 	return "", nil
 }
 
-func shortVerboseFormat(event TestEvent, exec *Execution) (string, error) {
+func testNameFormat(event TestEvent, exec *Execution) (string, error) {
 	result := colorEvent(event)(strings.ToUpper(string(event.Action)))
 	formatTest := func() string {
 		pkgPath := RelativePackagePath(event.Package)
@@ -117,7 +117,7 @@ func all(cond ...bool) bool {
 
 const cachedMessage = " (cached)"
 
-func shortFormat(event TestEvent, exec *Execution) (string, error) {
+func pkgNameFormat(event TestEvent, exec *Execution) (string, error) {
 	if !event.PackageEvent() {
 		return "", nil
 	}
@@ -163,7 +163,7 @@ func shortFormatPackageEvent(event TestEvent, exec *Execution) (string, error) {
 	return "", nil
 }
 
-func shortWithFailuresFormat(event TestEvent, exec *Execution) (string, error) {
+func pkgNameWithFailuresFormat(event TestEvent, exec *Execution) (string, error) {
 	if !event.PackageEvent() {
 		if event.Action == ActionFail {
 			pkg := exec.Package(event.Package)
@@ -207,11 +207,11 @@ func NewEventFormatter(out io.Writer, format string) EventFormatter {
 	case "dots-v2":
 		return newDotFormatter(out)
 	case "testname", "short-verbose":
-		return &formatAdapter{out, shortVerboseFormat}
+		return &formatAdapter{out, testNameFormat}
 	case "pkgname", "short":
-		return &formatAdapter{out, shortFormat}
+		return &formatAdapter{out, pkgNameFormat}
 	case "pkgname-and-test-fails", "short-with-failures":
-		return &formatAdapter{out, shortWithFailuresFormat}
+		return &formatAdapter{out, pkgNameWithFailuresFormat}
 	default:
 		return nil
 	}

--- a/testjson/format_test.go
+++ b/testjson/format_test.go
@@ -66,10 +66,10 @@ func patchPkgPathPrefix(val string) func() {
 	return func() { pkgPathPrefix = oldVal }
 }
 
-func TestScanTestOutputWithShortVerboseFormat(t *testing.T) {
+func TestScanTestOutput_WithTestNameFormat(t *testing.T) {
 	defer patchPkgPathPrefix("github.com/gotestyourself/gotestyourself")()
 
-	shim := newFakeHandlerWithAdapter(shortVerboseFormat, "go-test-json")
+	shim := newFakeHandlerWithAdapter(testNameFormat, "go-test-json")
 	exec, err := ScanTestOutput(shim.Config(t))
 
 	assert.NilError(t, err)
@@ -149,10 +149,10 @@ func TestScanTestOutputWithDotsFormatV1(t *testing.T) {
 	assert.DeepEqual(t, exec, expectedExecution, cmpExecutionShallow)
 }
 
-func TestScanTestOutputWithShortFormat(t *testing.T) {
+func TestScanTestOutput_WithPkgNameFormat(t *testing.T) {
 	defer patchPkgPathPrefix("github.com/gotestyourself/gotestyourself")()
 
-	shim := newFakeHandlerWithAdapter(shortFormat, "go-test-json")
+	shim := newFakeHandlerWithAdapter(pkgNameFormat, "go-test-json")
 	exec, err := ScanTestOutput(shim.Config(t))
 
 	assert.NilError(t, err)
@@ -161,10 +161,10 @@ func TestScanTestOutputWithShortFormat(t *testing.T) {
 	assert.DeepEqual(t, exec, expectedExecution, cmpExecutionShallow)
 }
 
-func TestScanTestOutputWithShortFormat_WithCoverage(t *testing.T) {
+func TestScanTestOutput_WithPkgNameFormat_WithCoverage(t *testing.T) {
 	defer patchPkgPathPrefix("gotest.tools")()
 
-	shim := newFakeHandlerWithAdapter(shortFormat, "go-test-json-with-cover")
+	shim := newFakeHandlerWithAdapter(pkgNameFormat, "go-test-json-with-cover")
 	exec, err := ScanTestOutput(shim.Config(t))
 
 	assert.NilError(t, err)

--- a/testjson/summary.go
+++ b/testjson/summary.go
@@ -82,7 +82,7 @@ func PrintSummary(out io.Writer, execution *Execution, opts Summary) {
 	}
 
 	fmt.Fprintf(out, "\n%s %d tests%s%s%s in %s\n",
-		formatExecStatus(execution.done),
+		formatExecStatus(execution),
 		execution.Total(),
 		formatTestCount(len(execution.Skipped()), "skipped", ""),
 		formatTestCount(len(execution.Failed()), "failure", "s"),
@@ -101,12 +101,15 @@ func formatTestCount(count int, category string, pluralize string) string {
 	return fmt.Sprintf(", %d %s", count, category)
 }
 
-// TODO: maybe color this?
-func formatExecStatus(done bool) string {
-	if done {
-		return "DONE"
+func formatExecStatus(exec *Execution) string {
+	if !exec.done {
+		return ""
 	}
-	return ""
+	var runs string
+	if exec.lastRunID > 0 {
+		runs = fmt.Sprintf(" %d runs,", exec.lastRunID+1)
+	}
+	return "DONE" + runs
 }
 
 // FormatDurationAsSeconds formats a time.Duration as a float with an s suffix.

--- a/testjson/summary.go
+++ b/testjson/summary.go
@@ -168,10 +168,11 @@ func writeTestCaseSummary(out io.Writer, execution executionSummary, conf testCa
 	}
 	fmt.Fprintln(out, "\n=== "+conf.header)
 	for _, tc := range testCases {
-		fmt.Fprintf(out, "=== %s: %s %s (%s)\n",
+		fmt.Fprintf(out, "=== %s: %s %s%s (%s)\n",
 			conf.prefix,
 			RelativePackagePath(tc.Package),
 			tc.Test,
+			formatRunID(tc.RunID),
 			FormatDurationAsSeconds(tc.Elapsed, 2))
 		for _, line := range execution.OutputLines(tc) {
 			if isRunLine(line) || conf.filter(tc.Test, line) {

--- a/testjson/summary_test.go
+++ b/testjson/summary_test.go
@@ -302,3 +302,18 @@ func TestPrintSummary_WithRepeatedTestCases(t *testing.T) {
 	PrintSummary(buf, exec, SummarizeAll)
 	golden.Assert(t, buf.String(), "bug-repeated-test-case-output.out")
 }
+
+func TestPrintSummary_WithRerunID(t *testing.T) {
+	_, reset := patchClock()
+	defer reset()
+
+	exec, err := ScanTestOutput(ScanConfig{
+		Stdout: bytes.NewReader(golden.Get(t, "go-test-json.out")),
+		RunID:  7,
+	})
+	assert.NilError(t, err)
+
+	buf := new(bytes.Buffer)
+	PrintSummary(buf, exec, SummarizeAll)
+	golden.Assert(t, buf.String(), "summary-with-run-id.out")
+}

--- a/testjson/testdata/summary-with-run-id.out
+++ b/testjson/testdata/summary-with-run-id.out
@@ -32,4 +32,4 @@ this is stderr
 === FAIL: github.com/gotestyourself/gotestyourself/testjson/internal/stub TestNestedWithFailure (re-run 7) (0.00s)
 
 
-DONE 46 tests, 4 skipped, 5 failures in 0.000s
+DONE 8 runs, 46 tests, 4 skipped, 5 failures in 0.000s

--- a/testjson/testdata/summary-with-run-id.out
+++ b/testjson/testdata/summary-with-run-id.out
@@ -1,0 +1,35 @@
+
+=== Skipped
+=== SKIP: github.com/gotestyourself/gotestyourself/testjson/internal/good TestSkipped (re-run 7) (0.00s)
+	good_test.go:23: 
+
+=== SKIP: github.com/gotestyourself/gotestyourself/testjson/internal/good TestSkippedWitLog (re-run 7) (0.00s)
+	good_test.go:27: the skip message
+
+=== SKIP: github.com/gotestyourself/gotestyourself/testjson/internal/stub TestSkipped (re-run 7) (0.00s)
+	stub_test.go:26: 
+
+=== SKIP: github.com/gotestyourself/gotestyourself/testjson/internal/stub TestSkippedWitLog (re-run 7) (0.00s)
+	stub_test.go:30: the skip message
+
+
+=== Failed
+=== FAIL: github.com/gotestyourself/gotestyourself/testjson/internal/badmain  (0.00s)
+sometimes main can exit 2
+FAIL	github.com/gotestyourself/gotestyourself/testjson/internal/badmain	0.010s
+
+=== FAIL: github.com/gotestyourself/gotestyourself/testjson/internal/stub TestFailed (re-run 7) (0.00s)
+	stub_test.go:34: this failed
+
+=== FAIL: github.com/gotestyourself/gotestyourself/testjson/internal/stub TestFailedWithStderr (re-run 7) (0.00s)
+this is stderr
+	stub_test.go:43: also failed
+
+=== FAIL: github.com/gotestyourself/gotestyourself/testjson/internal/stub TestNestedWithFailure/c (re-run 7) (0.00s)
+    --- FAIL: TestNestedWithFailure/c (0.00s)
+    	stub_test.go:65: failed
+
+=== FAIL: github.com/gotestyourself/gotestyourself/testjson/internal/stub TestNestedWithFailure (re-run 7) (0.00s)
+
+
+DONE 46 tests, 4 skipped, 5 failures in 0.000s


### PR DESCRIPTION
This should help make the re-runs easier to see. 

* If the `testname` format is used, the re-runs will include a `(re-run #)` on the Pass/Fail line.
* The failure summary will include a `(re-run #)` on the Fail line
* The DONE line will include the number of runs when there is more than 1

Also makes an exit status that is not 0 or 1 an error that aborts re-runs.