### PR TITLE
Build arm64 binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,7 +12,9 @@ builds:
       - darwin
       - windows
       - linux
-    goarch: [amd64]
+    goarch:
+      - amd64
+      - arm64
     env: [CGO_ENABLED=0]
 
 checksum:


### PR DESCRIPTION
We are trying to use gotestsum on arm64 box. We've successfully compiled and run it on the box ourselves, but it would be useful if the packages were just available.

## Testing done

* I've run a hand-compiled version on an arm64 box successfully.
* I've run goreleaser locally and the build was successful

```
$ goreleaser --snapshot --skip-publish --rm-dist


   • releasing...
   • loading config file       file=.goreleaser.yml
   • running before hooks
   • loading environment variables
   • getting and validating git state
      • releasing v0.5.1, commit f9e3d29fa4ca41477cee3177bd4bf03de789d60f
      • pipe skipped              error=disabled during snapshot mode
   • parsing tag
   • setting defaults
      • snapshotting
      • github/gitlab/gitea releases
      • project name
      • building binaries
      • creating source archive
      • archives
      • linux packages
      • snapcraft packages
      • calculating checksums
      • signing artifacts
      • docker images
      • artifactory
      • blobs
      • homebrew tap formula
      • scoop manifests
      • milestones
   • snapshotting
   • checking ./dist
      • --rm-dist is set, cleaning it up
   • writing effective config file
      • writing                   config=dist/config.yaml
   • generating changelog
      • pipe skipped              error=not available for snapshots
   • building binaries
      • building                  binary=/Users/katie/workspace/gotestsum/dist/gotestsum_linux_arm64/gotestsum
      • building                  binary=/Users/katie/workspace/gotestsum/dist/gotestsum_windows_amd64/gotestsum.exe
      • building                  binary=/Users/katie/workspace/gotestsum/dist/gotestsum_linux_amd64/gotestsum
      • building                  binary=/Users/katie/workspace/gotestsum/dist/gotestsum_darwin_amd64/gotestsum
   • archives
      • creating                  archive=dist/gotestsum_v0.5.1-SNAPSHOT-f9e3d29_windows_amd64.tar.gz
      • creating                  archive=dist/gotestsum_v0.5.1-SNAPSHOT-f9e3d29_linux_arm64.tar.gz
      • creating                  archive=dist/gotestsum_v0.5.1-SNAPSHOT-f9e3d29_darwin_amd64.tar.gz
      • creating                  archive=dist/gotestsum_v0.5.1-SNAPSHOT-f9e3d29_linux_amd64.tar.gz
   • creating source archive
      • pipe skipped              error=source pipe is disabled
   • linux packages
   • snapcraft packages
   • calculating checksums
      • checksumming              file=gotestsum_v0.5.1-SNAPSHOT-f9e3d29_windows_amd64.tar.gz
      • checksumming              file=gotestsum_v0.5.1-SNAPSHOT-f9e3d29_darwin_amd64.tar.gz
      • checksumming              file=gotestsum_v0.5.1-SNAPSHOT-f9e3d29_linux_amd64.tar.gz
      • checksumming              file=gotestsum_v0.5.1-SNAPSHOT-f9e3d29_linux_arm64.tar.gz
   • signing artifacts
   • docker images
      • pipe skipped              error=docker section is not configured
   • publishing
      • blobs
         • pipe skipped              error=blobs section is not configured
      • http upload
         • pipe skipped              error=uploads section is not configured
      • custom publisher
         • pipe skipped              error=publishers section is not configured
      • artifactory
         • pipe skipped              error=artifactory section is not configured
      • docker images
         • pipe skipped              error=publishing is disabled
      • snapcraft packages
         • pipe skipped              error=publishing is disabled
      • github/gitlab/gitea releases
         • pipe skipped              error=publishing is disabled
      • homebrew tap formula
         • token type                type=github
      • scoop manifests
         • pipe skipped              error=publishing is disabled
      • milestones
         • pipe skipped              error=publishing is disabled
   • release succeeded after 3.06s
```