### PR TITLE
Update running-without-go.md

### DIFF
--- a/docs/running-without-go.md
+++ b/docs/running-without-go.md
@@ -3,14 +3,22 @@
 `gotestsum` may be run without Go as long as the package to be tested has
 already been compiled using `go test -c`, and the `test2json` tool is available.
 
-The `test2json` tool can be compiled from the Go source tree.
+The `test2json` tool can be compiled from the Go source tree:
 
 ```sh
-curl -Lo go.zip "https://github.com/golang/go/archive/go1.13.5.zip"
+export GOVERSION=1.13.5
+curl -Lo go.zip "https://github.com/golang/go/archive/go${GOVERSION}.zip"
 unzip go.zip
 rm -f go.zip
-cd go-go1.13.5/src/cmd/test2json/
+cd go-go${GOVERSION}/src/cmd/test2json/
 env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" .
+mv test2json /usr/local/bin/test2json
+```
+
+Or if you have Go installed already:
+
+```sh
+env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o test2json -ldflags="-s -w" cmd/test2json
 mv test2json /usr/local/bin/test2json
 ```
 


### PR DESCRIPTION
Add simpler way to compile test2json for those that already have Go installed.