### PR TITLE
Add a signal handler to forward SIGINT to 'go test'

### DIFF
--- a/internal/signalhandlerdriver/main.go
+++ b/internal/signalhandlerdriver/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		log("missing required filename argument")
+		os.Exit(1)
+	}
+
+	pid := []byte(strconv.Itoa(os.Getpid()))
+	if err := ioutil.WriteFile(os.Args[1], pid, 0644); err != nil {
+		log("failed to write file:", err.Error())
+		os.Exit(1)
+	}
+
+	c := make(chan os.Signal, 1)
+	signal.Notify(c)
+
+	var s os.Signal
+	select {
+	case s = <-c:
+	case <-time.After(time.Minute):
+		log("timeout waiting for signal")
+		os.Exit(1)
+	}
+
+	log("Received signal:", s)
+	switch n := s.(type) {
+	case syscall.Signal:
+		os.Exit(100 + int(n))
+	default:
+		log("failed to parse signal number")
+		os.Exit(3)
+	}
+}
+
+func log(v ...interface{}) {
+	fmt.Fprintln(os.Stderr, v...)
+}

--- a/internal/text/testing.go
+++ b/internal/text/testing.go
@@ -35,7 +35,7 @@ func OpRemoveSummaryLineElapsedTime(line string) string {
 }
 
 func OpRemoveTestElapsedTime(line string) string {
-	if i := strings.Index(line, " (0.0"); i > 0 && i+8 == len(line) {
+	if i := strings.Index(line, " (0."); i > 0 && i+8 == len(line) {
 		return line[:i]
 	}
 	return line


### PR DESCRIPTION
Some test binaries may want to handle SIGINT to perform cleanup of
external resources. This signal handler will forward the interrupt
signal to the 'go test' process to give it a chance to cleanup before
shutting down.