### PR TITLE
Fix rerun-fails with compiled test binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Note that using `--rerun-fails` may require the use of other flags, depending on
 how you specify args to `go test`:
 
 * when used with `--raw-command` the re-run will pass additional arguments to
-  the command. The first arg is a `-run` flag with a regex that matches the test to re-run,
+  the command. The first arg is a `-test.run` flag with a regex that matches the test to re-run,
   and second is the name of a go package. These additional args can be passed to `go test`,
   or a test binary.
 * when used with any `go test` args (anything after `--` on the command line), the list of

--- a/rerunfails.go
+++ b/rerunfails.go
@@ -126,9 +126,9 @@ func (r *failureRecorder) count() int {
 func goTestRunFlagForTestCase(name string) string {
 	root, sub := testjson.SplitTestName(name)
 	if sub == "" {
-		return "-run=^" + name + "$"
+		return "-test.run=^" + name + "$"
 	}
-	return "-run=^" + root + "$/^" + sub + "$"
+	return "-test.run=^" + root + "$/^" + sub + "$"
 }
 
 func writeRerunFailsReport(opts *options, exec *testjson.Execution) error {

--- a/rerunfails_test.go
+++ b/rerunfails_test.go
@@ -49,11 +49,11 @@ func TestGoTestRunFlagFromTestCases(t *testing.T) {
 	var testCases = map[string]testCase{
 		"root test case": {
 			input:    "TestOne",
-			expected: "-run=^TestOne$",
+			expected: "-test.run=^TestOne$",
 		},
 		"sub test case": {
 			input:    "TestOne/SubtestA",
-			expected: "-run=^TestOne$/^SubtestA$",
+			expected: "-test.run=^TestOne$/^SubtestA$",
 		},
 	}
 	for name := range testCases {


### PR DESCRIPTION
Fixes #148

Both the compiled binary and the 'go test' command accept -test.run, but only 'go test' accepts -run. Change the flag so that rerun works with a compiled binary.