### PR TITLE
summary: fewer newlines and rename the no-summary flag to hide-summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,25 +62,25 @@ Following the formatted output is a summary of the test run. The summary include
    DONE 101 tests[, 3 skipped][, 2 failures][, 1 error] in 0.103s
    ```
 
-To disable parts of the summary use `--no-summary section`.
+To hide parts of the summary use `--hide-summary section`.
 
 
 **Example: hide skipped tests in the summary**
 ```
-gotestsum --no-summary=skipped
+gotestsum --hide-summary=skipped
 ```
 
 **Example: hide everything except the DONE line**
 ```
-gotestsum --no-summary=skipped,failed,errors,output
+gotestsum --hide-summary=skipped,failed,errors,output
 # or
-gotestsum --no-summary=all
+gotestsum --hide-summary=all
 ```
 
-**Example: hide output in the summary, only print names of failed and skipped tests
+**Example: hide test output in the summary, only print names of failed and skipped tests
 and errors**
 ```
-gotestsum --no-summary=output
+gotestsum --hide-summary=output
 ```
 
 ### JUnit XML output

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -12,12 +12,12 @@ import (
 	"gotest.tools/gotestsum/testjson"
 )
 
-type noSummaryValue struct {
+type hideSummaryValue struct {
 	value testjson.Summary
 }
 
-func newNoSummaryValue() *noSummaryValue {
-	return &noSummaryValue{value: testjson.SummarizeAll}
+func newHideSummaryValue() *hideSummaryValue {
+	return &hideSummaryValue{value: testjson.SummarizeAll}
 }
 
 func readAsCSV(val string) ([]string, error) {
@@ -27,7 +27,7 @@ func readAsCSV(val string) ([]string, error) {
 	return csv.NewReader(strings.NewReader(val)).Read()
 }
 
-func (s *noSummaryValue) Set(val string) error {
+func (s *hideSummaryValue) Set(val string) error {
 	v, err := readAsCSV(val)
 	if err != nil {
 		return err
@@ -43,11 +43,11 @@ func (s *noSummaryValue) Set(val string) error {
 	return nil
 }
 
-func (s *noSummaryValue) Type() string {
+func (s *hideSummaryValue) Type() string {
 	return "summary"
 }
 
-func (s *noSummaryValue) String() string {
+func (s *hideSummaryValue) String() string {
 	// flip all the bits, since the flag value is the negative of what is stored
 	return (testjson.SummarizeAll ^ s.value).String()
 }

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -8,20 +8,20 @@ import (
 
 func TestNoSummaryValue_SetAndString(t *testing.T) {
 	t.Run("none", func(t *testing.T) {
-		assert.Equal(t, newNoSummaryValue().String(), "none")
+		assert.Equal(t, newHideSummaryValue().String(), "none")
 	})
 	t.Run("one", func(t *testing.T) {
-		value := newNoSummaryValue()
+		value := newHideSummaryValue()
 		assert.NilError(t, value.Set("output"))
 		assert.Equal(t, value.String(), "output")
 	})
 	t.Run("some", func(t *testing.T) {
-		value := newNoSummaryValue()
+		value := newHideSummaryValue()
 		assert.NilError(t, value.Set("errors,failed"))
 		assert.Equal(t, value.String(), "failed,errors")
 	})
 	t.Run("bad value", func(t *testing.T) {
-		value := newNoSummaryValue()
+		value := newHideSummaryValue()
 		assert.ErrorContains(t, value.Set("bogus"), "must be one or more of")
 	})
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -39,7 +39,7 @@ func Run(name string, args []string) error {
 
 func setupFlags(name string) (*pflag.FlagSet, *options) {
 	opts := &options{
-		noSummary:                    newNoSummaryValue(),
+		hideSummary:                  newHideSummaryValue(),
 		junitTestCaseClassnameFormat: &junitFieldFormatValue{},
 		junitTestSuiteNameFormat:     &junitFieldFormatValue{},
 		postRunHookCmd:               &commandValue{},
@@ -60,8 +60,12 @@ func setupFlags(name string) (*pflag.FlagSet, *options) {
 		lookEnvWithDefault("GOTESTSUM_JSONFILE", ""),
 		"write all TestEvents to file")
 	flags.BoolVar(&opts.noColor, "no-color", color.NoColor, "disable color output")
-	flags.Var(opts.noSummary, "no-summary",
+
+	flags.Var(opts.hideSummary, "no-summary",
 		"do not print summary of: "+testjson.SummarizeAll.String())
+	flags.Lookup("no-summary").Hidden = true
+	flags.Var(opts.hideSummary, "hide-summary",
+		"hide sections of the summary: "+testjson.SummarizeAll.String())
 	flags.Var(opts.postRunHookCmd, "post-run-command",
 		"command to run after the tests have completed")
 
@@ -131,7 +135,7 @@ type options struct {
 	junitFile                    string
 	postRunHookCmd               *commandValue
 	noColor                      bool
-	noSummary                    *noSummaryValue
+	hideSummary                  *hideSummaryValue
 	junitTestSuiteNameFormat     *junitFieldFormatValue
 	junitTestCaseClassnameFormat *junitFieldFormatValue
 	rerunFailsMaxAttempts        int
@@ -214,7 +218,7 @@ func run(opts *options) error {
 }
 
 func finishRun(opts *options, exec *testjson.Execution, exitErr error) error {
-	testjson.PrintSummary(opts.stdout, exec, opts.noSummary.value)
+	testjson.PrintSummary(opts.stdout, exec, opts.hideSummary.value)
 
 	if err := writeJUnitFile(opts, exec); err != nil {
 		return err

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -318,7 +318,7 @@ func TestRun_RerunFails_WithTooManyInitialFailures(t *testing.T) {
 		rerunFailsMaxInitialFailures: 1,
 		stdout:                       out,
 		stderr:                       os.Stderr,
-		noSummary:                    newNoSummaryValue(),
+		hideSummary:                  newHideSummaryValue(),
 	}
 	err := run(opts)
 	assert.ErrorContains(t, err, "number of test failures (2) exceeds maximum (1)", out.String())
@@ -352,7 +352,7 @@ func TestRun_RerunFails_BuildErrorPreventsRerun(t *testing.T) {
 		rerunFailsMaxInitialFailures: 1,
 		stdout:                       out,
 		stderr:                       os.Stderr,
-		noSummary:                    newNoSummaryValue(),
+		hideSummary:                  newHideSummaryValue(),
 	}
 	err := run(opts)
 	assert.ErrorContains(t, err, "rerun aborted because previous run had errors", out.String())

--- a/cmd/testdata/e2e/expected/TestE2E_RerunFails/reruns_continues_to_fail
+++ b/cmd/testdata/e2e/expected/TestE2E_RerunFails/reruns_continues_to_fail
@@ -80,5 +80,4 @@ SEED:  3
 === FAIL: cmd/testdata/e2e/flaky TestFailsOften (re-run 2)
 SEED:  4
 
-
 DONE 3 runs, 14 tests, 8 failures

--- a/cmd/testdata/e2e/expected/TestE2E_RerunFails/reruns_continues_to_fail-go1.13
+++ b/cmd/testdata/e2e/expected/TestE2E_RerunFails/reruns_continues_to_fail-go1.13
@@ -80,5 +80,4 @@ SEED:  3
 === FAIL: cmd/testdata/e2e/flaky TestFailsOften (re-run 2)
 SEED:  4
 
-
 DONE 3 runs, 14 tests, 8 failures

--- a/cmd/testdata/e2e/expected/TestE2E_RerunFails/reruns_until_success
+++ b/cmd/testdata/e2e/expected/TestE2E_RerunFails/reruns_until_success
@@ -105,5 +105,4 @@ SEED:  4
 === FAIL: cmd/testdata/e2e/flaky TestFailsOften (re-run 3)
 SEED:  5
 
-
 DONE 5 runs, 18 tests, 10 failures

--- a/cmd/testdata/e2e/expected/TestE2E_RerunFails/reruns_until_success-go1.13
+++ b/cmd/testdata/e2e/expected/TestE2E_RerunFails/reruns_until_success-go1.13
@@ -105,5 +105,4 @@ SEED:  4
 === FAIL: cmd/testdata/e2e/flaky TestFailsOften (re-run 3)
 SEED:  5
 
-
 DONE 5 runs, 18 tests, 10 failures

--- a/cmd/testdata/gotestsum-help-text
+++ b/cmd/testdata/gotestsum-help-text
@@ -5,12 +5,12 @@ Usage:
 Flags:
       --debug                                       enabled debug logging
   -f, --format string                               print format of test input (default "short")
+      --hide-summary summary                        hide sections of the summary: skipped,failed,errors,output (default none)
       --jsonfile string                             write all TestEvents to file
       --junitfile string                            write a JUnit XML file
       --junitfile-testcase-classname field-format   format the testcase classname field as: full, relative, short (default full)
       --junitfile-testsuite-name field-format       format the testsuite name field as: full, relative, short (default full)
       --no-color                                    disable color output (default true)
-      --no-summary summary                          do not print summary of: skipped,failed,errors,output (default none)
       --packages list                               space separated list of package to test
       --post-run-command command                    command to run after the tests have completed
       --raw-command                                 don't prepend 'go test -json' to the 'go test' command

--- a/testjson/summary.go
+++ b/testjson/summary.go
@@ -170,7 +170,7 @@ func writeTestCaseSummary(out io.Writer, execution executionSummary, conf testCa
 		return
 	}
 	fmt.Fprintln(out, "\n=== "+conf.header)
-	for _, tc := range testCases {
+	for idx, tc := range testCases {
 		fmt.Fprintf(out, "=== %s: %s %s%s (%s)\n",
 			conf.prefix,
 			RelativePackagePath(tc.Package),
@@ -183,7 +183,7 @@ func writeTestCaseSummary(out io.Writer, execution executionSummary, conf testCa
 			}
 			fmt.Fprint(out, line)
 		}
-		if _, isNoOutput := execution.(*noOutputSummary); !isNoOutput {
+		if _, isNoOutput := execution.(*noOutputSummary); !isNoOutput && idx+1 != len(testCases) {
 			fmt.Fprintln(out)
 		}
 	}

--- a/testjson/summary.go
+++ b/testjson/summary.go
@@ -183,7 +183,9 @@ func writeTestCaseSummary(out io.Writer, execution executionSummary, conf testCa
 			}
 			fmt.Fprint(out, line)
 		}
-		fmt.Fprintln(out)
+		if _, isNoOutput := execution.(*noOutputSummary); !isNoOutput {
+			fmt.Fprintln(out)
+		}
 	}
 }
 

--- a/testjson/summary_test.go
+++ b/testjson/summary_test.go
@@ -186,16 +186,11 @@ DONE 13 tests, 1 skipped, 4 failures, 1 error in 34.123s
 === Skipped
 === SKIP: project/pkg/more TestOnlySometimes (0.00s)
 
-
 === Failed
 === FAIL: project/badmain  (0.00s)
-
 === FAIL: project/fs TestFileDo (1.41s)
-
 === FAIL: project/fs TestFileDoError (0.01s)
-
 === FAIL: project/pkg/more TestAlbatross (0.04s)
-
 
 === Errors
 pkg/file.go:99:12: missing ',' before newline

--- a/testjson/summary_test.go
+++ b/testjson/summary_test.go
@@ -155,7 +155,6 @@ Some stdout/stderr here
 === SKIP: project/pkg/more TestOnlySometimes (0.00s)
 	good_test.go:27: the skip message
 
-
 === Failed
 === FAIL: project/badmain  (0.00s)
 sometimes main can exit 2
@@ -168,7 +167,6 @@ Some stdout/stderr here
 	do_test.go:50 assertion failed: expected nil error, got WHAT!
 
 === FAIL: project/pkg/more TestAlbatross (0.04s)
-
 
 === Errors
 pkg/file.go:99:12: missing ',' before newline

--- a/testjson/testdata/bug-missing-skip-message-summary.out
+++ b/testjson/testdata/bug-missing-skip-message-summary.out
@@ -8,5 +8,4 @@ WARN Failed to detect terminal width for dots format, error: inappropriate ioctl
     TestGetPkgPathPrefix/with_go_path: pkgpathprefix_test.go:22: isGoModuleEnabled()
     --- SKIP: TestGetPkgPathPrefix/with_go_path (0.00s)
 
-
 DONE 42 tests, 2 skipped in 0.000s

--- a/testjson/testdata/bug-repeated-test-case-output.out
+++ b/testjson/testdata/bug-repeated-test-case-output.out
@@ -36,7 +36,6 @@
 === SKIP: github.com/gotestyourself/gotestyourself/testjson/internal/stub TestSkippedWitLog (0.00s)
 	stub_test.go:30: the skip message
 
-
 === Failed
 === FAIL: github.com/gotestyourself/gotestyourself/testjson/internal/badmain  (0.00s)
 sometimes main can exit 2
@@ -84,6 +83,5 @@ this is stderr
     	stub_test.go:65: failed
 
 === FAIL: github.com/gotestyourself/gotestyourself/testjson/internal/stub TestNestedWithFailure (0.00s)
-
 
 DONE 138 tests, 12 skipped, 13 failures in 0.000s

--- a/testjson/testdata/summary-misattributed-output
+++ b/testjson/testdata/summary-misattributed-output
@@ -17,5 +17,4 @@
             foo_test.go:26: output from sub2 test
     foo_test.go:32: output after sub test
 
-
 DONE 5 tests, 1 failure in 0.000s

--- a/testjson/testdata/summary-missing-test-fail-event
+++ b/testjson/testdata/summary-missing-test-fail-event
@@ -19,5 +19,4 @@ gotest.tools/v3/poll.WaitOn.func1(0xc00001e3c0, 0x67df50, 0x6c1960, 0xc00016c240
 created by gotest.tools/v3/poll.WaitOn
 	/home/daniel/pers/code/gotest.tools/poll/poll.go:124 +0x16f
 
-
 DONE 1 tests, 1 failure in 0.000s

--- a/testjson/testdata/summary-parallel-failures.out
+++ b/testjson/testdata/summary-parallel-failures.out
@@ -27,5 +27,4 @@
 === FAIL: testjson/internal/parallelfails TestParallelTheSecond (0.01s)
     TestParallelTheSecond: fails_test.go:35: failed the second
 
-
 DONE 12 tests, 8 failures in 0.000s

--- a/testjson/testdata/summary-root-test-has-subtest-failures
+++ b/testjson/testdata/summary-root-test-has-subtest-failures
@@ -12,7 +12,6 @@
 === SKIP: github.com/gotestyourself/gotestyourself/testjson/internal/stub TestSkippedWitLog (0.00s)
 	stub_test.go:30: the skip message
 
-
 === Failed
 === FAIL: github.com/gotestyourself/gotestyourself/testjson/internal/badmain  (0.00s)
 sometimes main can exit 2
@@ -30,6 +29,5 @@ this is stderr
     	stub_test.go:65: failed
 
 === FAIL: github.com/gotestyourself/gotestyourself/testjson/internal/stub TestNestedWithFailure (0.00s)
-
 
 DONE 46 tests, 4 skipped, 5 failures in 0.000s

--- a/testjson/testdata/summary-with-run-id.out
+++ b/testjson/testdata/summary-with-run-id.out
@@ -12,7 +12,6 @@
 === SKIP: github.com/gotestyourself/gotestyourself/testjson/internal/stub TestSkippedWitLog (re-run 7) (0.00s)
 	stub_test.go:30: the skip message
 
-
 === Failed
 === FAIL: github.com/gotestyourself/gotestyourself/testjson/internal/badmain  (0.00s)
 sometimes main can exit 2
@@ -30,6 +29,5 @@ this is stderr
     	stub_test.go:65: failed
 
 === FAIL: github.com/gotestyourself/gotestyourself/testjson/internal/stub TestNestedWithFailure (re-run 7) (0.00s)
-
 
 DONE 8 runs, 46 tests, 4 skipped, 5 failures in 0.000s


### PR DESCRIPTION
`--no-summary` is now hidden.

When `--hide-summary=output` is set, remove the newlines between test names.

Remove the extra newline between sections of the summary.