### PR TITLE
Add --max-fails flag for ending the test run

### DIFF
--- a/cmd/handler_test.go
+++ b/cmd/handler_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -70,4 +71,17 @@ func TestEventHandler_Event_WithMissingActionFail(t *testing.T) {
 	// confirm the artificial event was sent to the handler by checking the output
 	// of the formatter.
 	golden.Assert(t, errBuf.String(), "event-handler-missing-test-fail-expected")
+}
+
+func TestEventHandler_Event_MaxFails(t *testing.T) {
+	format := testjson.NewEventFormatter(ioutil.Discard, "testname")
+
+	source := golden.Get(t, "../../testjson/testdata/go-test-json.out")
+	cfg := testjson.ScanConfig{
+		Stdout:  bytes.NewReader(source),
+		Handler: &eventHandler{formatter: format, maxFails: 2},
+	}
+
+	_, err := testjson.ScanTestOutput(cfg)
+	assert.Error(t, err, "ending test run because max failures was reached")
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -87,6 +87,8 @@ func setupFlags(name string) (*pflag.FlagSet, *options) {
 		"command to run after the tests have completed")
 	flags.BoolVar(&opts.watch, "watch", false,
 		"watch go files, and run tests when a file is modified")
+	flags.IntVar(&opts.maxFails, "max-fails", 0,
+		"end the test run after this number of failures")
 
 	flags.StringVar(&opts.junitFile, "junitfile",
 		lookEnvWithDefault("GOTESTSUM_JUNITFILE", ""),
@@ -163,6 +165,7 @@ type options struct {
 	rerunFailsOnlyRootCases      bool
 	packages                     []string
 	watch                        bool
+	maxFails                     int
 	version                      bool
 
 	// shims for testing

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -211,10 +211,11 @@ func run(opts *options) error {
 		Stdout:  goTestProc.stdout,
 		Stderr:  goTestProc.stderr,
 		Handler: handler,
+		Stop:    cancel,
 	}
 	exec, err := testjson.ScanTestOutput(cfg)
 	if err != nil {
-		return err
+		return finishRun(opts, exec, err)
 	}
 	exitErr := goTestProc.cmd.Wait()
 	if exitErr == nil || opts.rerunFailsMaxAttempts == 0 {

--- a/cmd/rerunfails.go
+++ b/cmd/rerunfails.go
@@ -44,6 +44,8 @@ func rerunFailsFilter(o *options) testCaseFilter {
 }
 
 func rerunFailed(ctx context.Context, opts *options, scanConfig testjson.ScanConfig) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	tcFilter := rerunFailsFilter(opts)
 
 	rec := newFailureRecorderFromExecution(scanConfig.Execution)
@@ -64,6 +66,7 @@ func rerunFailed(ctx context.Context, opts *options, scanConfig testjson.ScanCon
 				Stderr:    goTestProc.stderr,
 				Handler:   nextRec,
 				Execution: scanConfig.Execution,
+				Stop:      cancel,
 			}
 			if _, err := testjson.ScanTestOutput(cfg); err != nil {
 				return err

--- a/cmd/testdata/e2e/expected/TestE2E_MaxFails_EndTestRun
+++ b/cmd/testdata/e2e/expected/TestE2E_MaxFails_EndTestRun
@@ -1,0 +1,11 @@
+
+=== Failed
+=== FAIL: cmd/testdata/e2e/flaky TestFailsRarely
+SEED:  0
+    flaky_test.go:51: not this time
+
+=== FAIL: cmd/testdata/e2e/flaky TestFailsSometimes
+SEED:  0
+    flaky_test.go:58: not this time
+
+DONE 3 tests, 2 failures

--- a/cmd/testdata/gotestsum-help-text
+++ b/cmd/testdata/gotestsum-help-text
@@ -10,6 +10,7 @@ Flags:
       --junitfile string                            write a JUnit XML file
       --junitfile-testcase-classname field-format   format the testcase classname field as: full, relative, short (default full)
       --junitfile-testsuite-name field-format       format the testsuite name field as: full, relative, short (default full)
+      --max-fails int                               end the test run after this number of failures
       --no-color                                    disable color output (default true)
       --packages list                               space separated list of package to test
       --post-run-command command                    command to run after the tests have completed

--- a/testjson/execution.go
+++ b/testjson/execution.go
@@ -522,6 +522,8 @@ type ScanConfig struct {
 	// Execution to populate while scanning. If nil a new one will be created
 	// and returned from ScanTestOutput.
 	Execution *Execution
+	// Stop is called when ScanTestOutput fails during a scan.
+	Stop func()
 }
 
 // EventHandler is called by ScanTestOutput for each event and write to stderr.
@@ -548,6 +550,9 @@ func ScanTestOutput(config ScanConfig) (*Execution, error) {
 	if config.Stderr == nil {
 		config.Stderr = new(bytes.Reader)
 	}
+	if config.Stop == nil {
+		config.Stop = func() {}
+	}
 	execution := config.Execution
 	if execution == nil {
 		execution = newExecution()
@@ -557,21 +562,27 @@ func ScanTestOutput(config ScanConfig) (*Execution, error) {
 
 	var group errgroup.Group
 	group.Go(func() error {
-		return readStdout(config, execution)
+		if err := readStdout(config, execution); err != nil {
+			config.Stop()
+			return err
+		}
+		return nil
 	})
 	group.Go(func() error {
-		return readStderr(config, execution)
+		if err := readStderr(config, execution); err != nil {
+			config.Stop()
+			return err
+		}
+		return nil
 	})
-	if err := group.Wait(); err != nil {
-		return execution, err
-	}
+
+	err := group.Wait()
 	for _, event := range execution.end() {
 		if err := config.Handler.Event(event, execution); err != nil {
 			return execution, err
 		}
 	}
-
-	return execution, nil
+	return execution, err
 }
 
 func readStdout(config ScanConfig, execution *Execution) error {

--- a/testjson/execution.go
+++ b/testjson/execution.go
@@ -562,18 +562,10 @@ func ScanTestOutput(config ScanConfig) (*Execution, error) {
 
 	var group errgroup.Group
 	group.Go(func() error {
-		if err := readStdout(config, execution); err != nil {
-			config.Stop()
-			return err
-		}
-		return nil
+		return stopOnError(config.Stop, readStdout(config, execution))
 	})
 	group.Go(func() error {
-		if err := readStderr(config, execution); err != nil {
-			config.Stop()
-			return err
-		}
-		return nil
+		return stopOnError(config.Stop, readStderr(config, execution))
 	})
 
 	err := group.Wait()
@@ -583,6 +575,14 @@ func ScanTestOutput(config ScanConfig) (*Execution, error) {
 		}
 	}
 	return execution, err
+}
+
+func stopOnError(stop func(), err error) error {
+	if err != nil {
+		stop()
+		return err
+	}
+	return nil
 }
 
 func readStdout(config ScanConfig, execution *Execution) error {


### PR DESCRIPTION
Also fixes a bug where failures from reading stdout/stderr would not actually stop the test run.

Related upstream issue https://github.com/golang/go/issues/33038