### PR TITLE
Add rerun for --watch mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,8 @@ tests for the package which contains the changed file. By default all
 directories under the current directory will be watched. Use the `--packages` flag
 to specify a different list.
 
+While in watch mode, pressing `r` will re-run the tests for the previous event.
+
 **Example: run tests for a package when any file in that package is saved**
 ```
 gotestsum --watch --format testname

--- a/internal/filewatcher/term_bsd.go
+++ b/internal/filewatcher/term_bsd.go
@@ -1,0 +1,8 @@
+// +build darwin dragonfly freebsd netbsd openbsd
+
+package filewatcher
+
+import "golang.org/x/sys/unix"
+
+const tcGet = unix.TIOCGETA
+const tcSet = unix.TIOCSETA

--- a/internal/filewatcher/term_linux.go
+++ b/internal/filewatcher/term_linux.go
@@ -1,0 +1,6 @@
+package filewatcher
+
+import "golang.org/x/sys/unix"
+
+const tcGet = unix.TCGETS
+const tcSet = unix.TCSETS

--- a/internal/filewatcher/term_unix.go
+++ b/internal/filewatcher/term_unix.go
@@ -1,0 +1,67 @@
+// +build !windows
+
+package filewatcher
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+	"gotest.tools/gotestsum/log"
+)
+
+func enableNonBlockingRead(fd int) (func(), error) {
+	term, err := unix.IoctlGetTermios(fd, tcGet)
+	if err != nil {
+		return nil, err
+	}
+
+	state := *term
+	reset := func() {
+		if err := unix.IoctlSetTermios(fd, tcSet, &state); err != nil {
+			log.Debugf("failed to reset fd %d: %v", fd, err)
+		}
+	}
+
+	term.Lflag &^= unix.ECHO | unix.ICANON
+	term.Cc[unix.VMIN] = 1
+	term.Cc[unix.VTIME] = 0
+	if err := unix.IoctlSetTermios(fd, tcSet, term); err != nil {
+		reset()
+		return nil, err
+	}
+	return reset, nil
+}
+
+func (r *redoHandler) run(ctx context.Context) {
+	fd := int(os.Stdin.Fd())
+	reset, err := enableNonBlockingRead(fd)
+	if err != nil {
+		log.Debugf("failed to put terminal (fd %d) into raw mode: %v", fd, err)
+		return
+	}
+	defer reset()
+
+	in := bufio.NewReader(os.Stdin)
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		char, err := in.ReadByte()
+		if err != nil {
+			log.Warnf("failed to read input: %v", err)
+			return
+		}
+		log.Debugf("received byte %v (%v)", char, string(char))
+
+		switch char {
+		case 'r':
+			r.ch <- r.prevPath
+		case '\n':
+			fmt.Println()
+		}
+	}
+}

--- a/internal/filewatcher/term_windows.go
+++ b/internal/filewatcher/term_windows.go
@@ -1,0 +1,7 @@
+package filewatcher
+
+import "context"
+
+func (r *redoHandler) run(_ context.Context) {
+	return
+}


### PR DESCRIPTION
When watching for file changes, pressing the `r` key will re-run tests for the last
package that was run.

Also, mostly incidentally because of the terminal mode, removes echo'ing of characters
pressed while in watch mode. The newline character is handled as a special case
and printed to stdout so that it is still possible to clear part of the screen while
in watch mode.

Only works on unix (not windows), and has only been tested on linux.