### PR TITLE
watch: properly reset terminal after idle timeout

### DIFF
--- a/internal/filewatcher/term_windows.go
+++ b/internal/filewatcher/term_windows.go
@@ -2,6 +2,18 @@ package filewatcher
 
 import "context"
 
-func (r *redoHandler) run(_ context.Context) {
-	return
+type redoHandler struct{}
+
+func newRedoHandler() *redoHandler {
+	return nil
 }
+
+func (r *redoHandler) Run(_ context.Context) {}
+
+func (r *redoHandler) Ch() <-chan string {
+	return nil
+}
+
+func (r *redoHandler) Reset() {}
+
+func (r *redoHandler) Save(_ string) {}


### PR DESCRIPTION
Fixes a bug from #160

Previous the terminal would not be reset because the defer was in the
redo handler goroutine. This goroutine accepts a context, but because it
blocks on reading from stdin, it does not exit when the context is
cancelled.

To fix the problem, the defer is moved into the main goroutine.