### PR TITLE
support goarch mips64le architecture.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,6 +15,7 @@ builds:
     goarch:
       - amd64
       - arm64
+      - mips64le
     env: [CGO_ENABLED=0]
     ldflags: ["-s -w -X gotest.tools/gotestsum/cmd.version={{.Version}}"]
 


### PR DESCRIPTION
hello，I am going to submit mips64le architecture，The main reasons for adding support for mips64le architecture are:
1、The mips64le architecture is also the mainstream cpu architecture (amd64, arm64), which is used by many users;
2、Golang supports cross compilation, and mips64le is officially supported.
Therefore, I hope that the release package also supports the mips64le architecture, which is convenient for more users.
Signed-off-by: houfangdong houfangdong@loongson.com