### PR TITLE
Replace spf13/pflag with dnephin/pflag

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -5,9 +5,9 @@ import (
 	"path"
 	"strings"
 
+	"github.com/dnephin/pflag"
 	"github.com/google/shlex"
 	"github.com/pkg/errors"
-	"github.com/spf13/pflag"
 	"gotest.tools/gotestsum/internal/junitxml"
 	"gotest.tools/gotestsum/testjson"
 )

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -9,9 +9,9 @@ import (
 	"os/signal"
 	"strings"
 
+	"github.com/dnephin/pflag"
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
-	"github.com/spf13/pflag"
 	"gotest.tools/gotestsum/log"
 	"gotest.tools/gotestsum/testjson"
 )

--- a/cmd/tool/slowest/slowest.go
+++ b/cmd/tool/slowest/slowest.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/spf13/pflag"
+	"github.com/dnephin/pflag"
 	"gotest.tools/gotestsum/internal/aggregate"
 	"gotest.tools/gotestsum/log"
 	"gotest.tools/gotestsum/testjson"

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,7 @@
 module gotest.tools/gotestsum
 
-replace github.com/spf13/pflag => github.com/dnephin/pflag v0.0.0-20200521001137-0f09ccd3add8
-
 require (
+	github.com/dnephin/pflag v1.0.7
 	github.com/fatih/color v1.9.0
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/google/go-cmp v0.5.2
@@ -10,7 +9,6 @@ require (
 	github.com/jonboulle/clockwork v0.1.0
 	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/pkg/errors v0.9.1
-	github.com/spf13/pflag v1.0.3
 	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/dnephin/pflag v0.0.0-20200521001137-0f09ccd3add8 h1:7JFEKdSKf4LLYMqIMxjwffbi7sdmW+SQU9Ec2vETFHs=
-github.com/dnephin/pflag v0.0.0-20200521001137-0f09ccd3add8/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/dnephin/pflag v1.0.7 h1:oxONGlWxhmUct0YzKTgrpQv9AUA1wtPBn7zuSjJqptk=
+github.com/dnephin/pflag v1.0.7/go.mod h1:uxE91IoWURlOiTUIA8Mq5ZZkAv3dPUfZNaT80Zm7OQE=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
@@ -24,6 +24,7 @@ github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a h1:oWX7TPOiFAMXLq8o0ikBYfCJVlRHBcsciT5bXOrH628=


### PR DESCRIPTION
Fixes #176
Closes #177

The replace directive was preventing the new go1.16 support for running `go install gotest.tools/gotestsum@latest`.

Since upstream has not yet merged the PR to remove special handling for `-test.x` flags, replace the upstream with my fork.