### PR TITLE
replace all usages of os/exec with golang.org/x/sys/execabs

### DIFF
--- a/cmd/handler.go
+++ b/cmd/handler.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 
 	"github.com/pkg/errors"
+	exec "golang.org/x/sys/execabs"
 	"gotest.tools/gotestsum/internal/junitxml"
 	"gotest.tools/gotestsum/log"
 	"gotest.tools/gotestsum/testjson"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"os/signal"
 	"strings"
 
 	"github.com/dnephin/pflag"
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
+	exec "golang.org/x/sys/execabs"
 	"gotest.tools/gotestsum/log"
 	"gotest.tools/gotestsum/testjson"
 )

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -3,10 +3,10 @@ package cmd
 import (
 	"bytes"
 	"os"
-	"os/exec"
 	"strings"
 	"testing"
 
+	exec "golang.org/x/sys/execabs"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/env"
 	"gotest.tools/v3/golden"

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 
+	exec "golang.org/x/sys/execabs"
 	"gotest.tools/gotestsum/internal/filewatcher"
 	"gotest.tools/gotestsum/testjson"
 )

--- a/contrib/notify/notify-macos.go
+++ b/contrib/notify/notify-macos.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
 	"strconv"
+
+	exec "golang.org/x/sys/execabs"
 )
 
 func main() {

--- a/internal/junitxml/report.go
+++ b/internal/junitxml/report.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"strings"
 	"time"
 
+	exec "golang.org/x/sys/execabs"
 	"gotest.tools/gotestsum/log"
 	"gotest.tools/gotestsum/testjson"
 )

--- a/main.go
+++ b/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"os"
-	"os/exec"
 
+	exec "golang.org/x/sys/execabs"
 	"gotest.tools/gotestsum/cmd"
 	"gotest.tools/gotestsum/cmd/tool"
 	"gotest.tools/gotestsum/log"


### PR DESCRIPTION
follow-up to https://github.com/gotestyourself/gotestsum/pull/182, only the last commit is new

Following the changes in Go, and golang.org/x/tools themselves, this change
ensures that packages using exec.LookPath or exec.Command to find or run
binaries do not accidentally run programs from the current directory when
they mean to run programs from the system PATH instead.