### PR TITLE
format: handle 'testing: warning: no tests to run' event

### DIFF
--- a/internal/junitxml/testdata/junitxml-report.golden
+++ b/internal/junitxml/testdata/junitxml-report.golden
@@ -80,4 +80,9 @@
 		<testcase classname="github.com/gotestyourself/gotestyourself/testjson/internal/stub" name="TestParallelTheSecond" time="0.010000"></testcase>
 		<testcase classname="github.com/gotestyourself/gotestyourself/testjson/internal/stub" name="TestParallelTheFirst" time="0.010000"></testcase>
 	</testsuite>
+	<testsuite tests="0" failures="0" time="0.000000" name="gotest.tools/gotestsum/internal/empty">
+		<properties>
+			<property name="go.version" value="go7.7.7"></property>
+		</properties>
+	</testsuite>
 </testsuites>

--- a/testjson/dotformat_test.go
+++ b/testjson/dotformat_test.go
@@ -18,6 +18,8 @@ import (
 )
 
 func TestScanTestOutput_WithDotsFormatter(t *testing.T) {
+	skip.If(t, runtime.GOOS == "windows")
+
 	defer patchPkgPathPrefix("github.com/gotestyourself/gotestyourself")()
 
 	out := new(bytes.Buffer)

--- a/testjson/execution.go
+++ b/testjson/execution.go
@@ -32,6 +32,16 @@ const (
 	ActionSkip   Action = "skip"
 )
 
+// IsTerminal returns true if the Action is one of: pass, fail, skip.
+func (a Action) IsTerminal() bool {
+	switch a {
+	case ActionPass, ActionFail, ActionSkip:
+		return true
+	default:
+		return false
+	}
+}
+
 // TestEvent is a structure output by go tool test2json and go test -json.
 type TestEvent struct {
 	// Time encoded as an RFC3339-format string
@@ -390,6 +400,10 @@ func isCoverageOutput(output string) bool {
 
 func isCachedOutput(output string) bool {
 	return strings.Contains(output, "\t(cached)")
+}
+
+func isWarningNoTestsToRunOutput(output string) bool {
+	return output == "testing: warning: no tests to run\n"
 }
 
 // OutputLines returns the full test output for a test as an slice of lines.

--- a/testjson/format_test.go
+++ b/testjson/format_test.go
@@ -112,6 +112,9 @@ var expectedExecution = &Execution{
 			action:  ActionFail,
 			running: map[string]TestCase{},
 		},
+		"gotest.tools/gotestsum/internal/empty": {
+			action: ActionPass,
+		},
 	},
 }
 

--- a/testjson/testdata/dots-format.out
+++ b/testjson/testdata/dots-format.out
@@ -702,3 +702,11 @@
   20ms testjson/internal/stub ···↷↷✖·✖····✖··✖············
 
  46 tests, 4 skipped, 5 failures, 1 error
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
+
+       testjson/internal/badmain 
+    🖴  testjson/internal/good ···↷↷·············
+  20ms testjson/internal/stub ···↷↷✖·✖····✖··✖············
+       gotest.tools/gotestsum/internal/empty 
+
+ 46 tests, 4 skipped, 5 failures, 1 error

--- a/testjson/testdata/go-test-json.out
+++ b/testjson/testdata/go-test-json.out
@@ -229,3 +229,7 @@
 {"Time":"2018-03-22T22:33:35.288005158Z","Action":"output","Package":"github.com/gotestyourself/gotestyourself/testjson/internal/stub","Output":"FAIL\n"}
 {"Time":"2018-03-22T22:33:35.288154141Z","Action":"output","Package":"github.com/gotestyourself/gotestyourself/testjson/internal/stub","Output":"FAIL\tgithub.com/gotestyourself/gotestyourself/testjson/internal/stub\t0.011s\n"}
 {"Time":"2018-03-22T22:33:35.288167612Z","Action":"fail","Package":"github.com/gotestyourself/gotestyourself/testjson/internal/stub","Elapsed":0.011}
+{"Time":"2021-03-28T13:58:17.979131051-04:00","Action":"output","Package":"gotest.tools/gotestsum/internal/empty","Output":"testing: warning: no tests to run\n"}
+{"Time":"2021-03-28T13:58:17.979525677-04:00","Action":"output","Package":"gotest.tools/gotestsum/internal/empty","Output":"PASS\n"}
+{"Time":"2021-03-28T13:58:17.979689639-04:00","Action":"output","Package":"gotest.tools/gotestsum/internal/empty","Output":"ok  \tgotest.tools/gotestsum/internal/empty\t0.004s [no tests to run]\n"}
+{"Time":"2021-03-28T13:58:17.979759254-04:00","Action":"pass","Package":"gotest.tools/gotestsum/internal/empty","Elapsed":0.004}

--- a/testjson/testdata/go-test-verbose.out
+++ b/testjson/testdata/go-test-verbose.out
@@ -122,3 +122,6 @@ this is stderr
 --- PASS: TestParallelTheFirst (0.01s)
 FAIL
 FAIL	github.com/gotestyourself/gotestyourself/testjson/internal/stub	0.011s
+testing: warning: no tests to run
+PASS
+ok  	gotest.tools/gotestsum/internal/empty	0.004s [no tests to run]

--- a/testjson/testdata/short-format.out
+++ b/testjson/testdata/short-format.out
@@ -1,3 +1,4 @@
 ✖  testjson/internal/badmain (10ms)
 ✓  testjson/internal/good (cached)
 ✖  testjson/internal/stub (11ms)
+∅  gotest.tools/gotestsum/internal/empty (4ms)

--- a/testjson/testdata/short-verbose-format.out
+++ b/testjson/testdata/short-verbose-format.out
@@ -56,3 +56,4 @@ PASS testjson/internal/stub.TestParallelTheThird (0.00s)
 PASS testjson/internal/stub.TestParallelTheSecond (0.01s)
 PASS testjson/internal/stub.TestParallelTheFirst (0.01s)
 FAIL testjson/internal/stub
+EMPTY gotest.tools/gotestsum/internal/empty

--- a/testjson/testdata/standard-quiet-format.out
+++ b/testjson/testdata/standard-quiet-format.out
@@ -3,3 +3,4 @@ FAIL	github.com/gotestyourself/gotestyourself/testjson/internal/badmain	0.010s
 ok  	github.com/gotestyourself/gotestyourself/testjson/internal/good	(cached)
 FAIL
 FAIL	github.com/gotestyourself/gotestyourself/testjson/internal/stub	0.011s
+ok  	gotest.tools/gotestsum/internal/empty	0.004s [no tests to run]


### PR DESCRIPTION
Fixes #140

An output event with this text is sent when 'go test' runs a package that has test files but no tests.

Update two formts that were printing this message in a way that was confusing. Now the standard-quiet format
properly matches 'go test' format, and the testname format omits the text. Since gotestsum includes a count
of tests run in the summary line, this message doesn't seem like it provides much value.