### PR TITLE
Use go1.16 for build and publish jobs in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,9 @@ jobs:
       publish:
         type: boolean
         default: false
-    executor: go/golang
+    executor:
+      name: go/golang
+      tag: 1.16-alpine
     steps:
       - go/install: {package: git}
       - go/install-ssh


### PR DESCRIPTION
Fixes #186 