### PR TITLE
Handle missing "pass" event for subtests

### DIFF
--- a/testjson/execution_test.go
+++ b/testjson/execution_test.go
@@ -107,3 +107,30 @@ func TestParseEvent(t *testing.T) {
 	cmpTestEvent := cmp.AllowUnexported(TestEvent{})
 	assert.DeepEqual(t, event, expected, cmpTestEvent)
 }
+
+func TestPassageCascades(t *testing.T) {
+	exec := newExecution()
+	exec.add(TestEvent{
+		Package: "mytestpkg",
+		Action:  ActionRun,
+		Test:    "TestFoo",
+	})
+	exec.add(TestEvent{
+		Package: "mytestpkg",
+		Action:  ActionRun,
+		Test:    "TestFoo/child",
+	})
+	exec.add(TestEvent{
+		Package: "mytestpkg",
+		Action:  ActionPass,
+		Test:    "TestFoo",
+	})
+
+	passed := exec.packages["mytestpkg"].Passed
+	assert.Equal(t, 2, len(passed))
+	if len(passed) != 2 {
+		return
+	}
+	assert.Equal(t, "TestFoo", string(passed[0].Test))
+	assert.Equal(t, "TestFoo/child", string(passed[1].Test))
+}


### PR DESCRIPTION
Sometimes no "pass" event is present for subtests in the JSON output,
even though the output indicates the subtests passed (with "--- PASS:")
and the parent test had a pass event. In these cases, gotestsum can
output spurious failure messages for the subtests. Handle this by
treating a pass event for a parent test as implying that the subtests
also passed.