### PR TITLE
Avoid rerun of failed tests when previous run had a panic

### DIFF
--- a/cmd/rerunfails.go
+++ b/cmd/rerunfails.go
@@ -94,6 +94,8 @@ func hasErrors(err error, exec *testjson.Execution) error {
 	// Exit code 0 and 1 are expected.
 	case ExitCodeWithDefault(err) > 1:
 		return fmt.Errorf("unexpected go test exit code: %v", err)
+	case exec.HasPanic():
+		return fmt.Errorf("rerun aborted because previous run had a suspected panic and some test may not have run")
 	default:
 		return nil
 	}


### PR DESCRIPTION
Mitigates the upstream go bug: https://github.com/golang/go/issues/45508

Since re-running tests requires knowledge of all tests, attempting a re-run after a panic is not safe. `gotestsum` will not be aware of any of the tests that did not run, so many tests could be skipped if a rerun is attempted.

Ideally the exit code of the `go test` process would be 2 in this case, but until that changes we are forced to rely on string comparison of the output.