### PR TITLE
watch: add action for reloading watched directory list

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,8 +309,8 @@ When the `--watch` flag is set, `gotestsum` will watch directories using
 [file system notifications](https://pkg.go.dev/github.com/fsnotify/fsnotify).
 When a Go file in one of those directories is modified, `gotestsum` will run the
 tests for the package which contains the changed file. By default all
-directories under the current directory will be watched. Use the `--packages` flag
-to specify a different list.
+directories with at least one file with a `.go` extension, under the current
+directory will be watched. Use the `--packages` flag to specify a different list.
 
 While in watch mode, pressing some keys will perform an action:
 
@@ -321,6 +321,9 @@ While in watch mode, pressing some keys will perform an action:
   breakpoints can be added with [`runtime.Breakpoint`](https://golang.org/pkg/runtime/#Breakpoint)
   or by using the delve command prompt.
 * `a` will run tests for all packages, by using `./...` as the package selector.
+* `l` will scan the directory list again, and if there are any new directories
+  which contain a file with a `.go` extension, they will be added to the watch
+  list.
 
 Note that [delve] must be installed in order to use debug (`d`).
 

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -22,15 +22,15 @@ type watchRuns struct {
 	prevExec *testjson.Execution
 }
 
-func (w *watchRuns) run(runOpts filewatcher.RunOptions) error {
-	if runOpts.Debug {
+func (w *watchRuns) run(event filewatcher.Event) error {
+	if event.Debug {
 		path, cleanup, err := delveInitFile(w.prevExec)
 		if err != nil {
 			return fmt.Errorf("failed to write delve init file: %w", err)
 		}
 		defer cleanup()
 		o := delveOpts{
-			pkgPath:      runOpts.PkgPath,
+			pkgPath:      event.PkgPath,
 			args:         w.opts.args,
 			initFilePath: path,
 		}
@@ -41,7 +41,7 @@ func (w *watchRuns) run(runOpts filewatcher.RunOptions) error {
 	}
 
 	opts := w.opts
-	opts.packages = []string{runOpts.PkgPath}
+	opts.packages = []string{event.PkgPath}
 	var err error
 	if w.prevExec, err = runSingle(&opts); !isExitCoder(err) {
 		return err

--- a/internal/filewatcher/term_unix.go
+++ b/internal/filewatcher/term_unix.go
@@ -83,6 +83,9 @@ func (r *redoHandler) Run(ctx context.Context) {
 		case 'a':
 			chResume = make(chan struct{})
 			r.ch <- RunOptions{resume: chResume, PkgPath: "./..."}
+		case 'l':
+			chResume = make(chan struct{})
+			r.ch <- RunOptions{resume: chResume, reloadPaths: true}
 		case '\n':
 			fmt.Println()
 			continue

--- a/internal/filewatcher/term_windows.go
+++ b/internal/filewatcher/term_windows.go
@@ -2,18 +2,18 @@ package filewatcher
 
 import "context"
 
-type redoHandler struct{}
+type terminal struct{}
 
-func newRedoHandler() *redoHandler {
+func newTerminal() *terminal {
 	return nil
 }
 
-func (r *redoHandler) Run(_ context.Context) {}
+func (r *terminal) Monitor(context.Context) {}
 
-func (r *redoHandler) Ch() <-chan RunOptions {
+func (r *terminal) Events() <-chan Event {
 	return nil
 }
 
-func (r *redoHandler) SetupTerm() {}
+func (r *terminal) Start() {}
 
-func (r *redoHandler) ResetTerm() {}
+func (r *terminal) Reset() {}

--- a/internal/filewatcher/watch_test.go
+++ b/internal/filewatcher/watch_test.go
@@ -22,7 +22,7 @@ func TestHandler_HandleEvent(t *testing.T) {
 
 	fn := func(t *testing.T, tc testCase) {
 		var ran bool
-		run := func(opts RunOptions) error {
+		run := func(opts Event) error {
 			ran = true
 			return nil
 		}


### PR DESCRIPTION
When files and directories are added, sometimes they won't be noticed because `gotestsum` only watches directories which already contained `.go` files. This new `l` action makes it possible to add these new directories without restarting `gotestsum`.