### PR TITLE
junit: Add timestamp for suite start time

### DIFF
--- a/internal/junitxml/report.go
+++ b/internal/junitxml/report.go
@@ -31,6 +31,7 @@ type JUnitTestSuite struct {
 	Name       string          `xml:"name,attr"`
 	Properties []JUnitProperty `xml:"properties>property,omitempty"`
 	TestCases  []JUnitTestCase
+	Timestamp  string `xml:"timestamp,attr"`
 }
 
 // JUnitTestCase is a single test case with its result.
@@ -92,6 +93,7 @@ func generate(exec *testjson.Execution, cfg Config) JUnitTestSuites {
 			Properties: packageProperties(version),
 			TestCases:  packageTestCases(pkg, cfg.FormatTestCaseClassname),
 			Failures:   len(pkg.Failed),
+			Timestamp:  exec.Started().Format(time.RFC3339),
 		}
 		suites.Suites = append(suites.Suites, junitpkg)
 	}

--- a/internal/junitxml/report.go
+++ b/internal/junitxml/report.go
@@ -66,6 +66,8 @@ type JUnitFailure struct {
 type Config struct {
 	FormatTestSuiteName     FormatFunc
 	FormatTestCaseClassname FormatFunc
+	// This is used for tests to have a consistent timestamp
+	customTimestamp string
 }
 
 // FormatFunc converts a string from one format into another.
@@ -93,7 +95,10 @@ func generate(exec *testjson.Execution, cfg Config) JUnitTestSuites {
 			Properties: packageProperties(version),
 			TestCases:  packageTestCases(pkg, cfg.FormatTestCaseClassname),
 			Failures:   len(pkg.Failed),
-			Timestamp:  exec.Started().Format(time.RFC3339),
+			Timestamp:  cfg.customTimestamp,
+		}
+		if cfg.customTimestamp == "" {
+			junitpkg.Timestamp = exec.Started().Format(time.RFC3339)
 		}
 		suites.Suites = append(suites.Suites, junitpkg)
 	}

--- a/internal/junitxml/report_test.go
+++ b/internal/junitxml/report_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"runtime"
 	"testing"
+	"time"
 
 	"gotest.tools/gotestsum/testjson"
 	"gotest.tools/v3/assert"
@@ -19,7 +20,7 @@ func TestWrite(t *testing.T) {
 	exec := createExecution(t)
 
 	defer env.Patch(t, "GOVERSION", "go7.7.7")()
-	err := Write(out, exec, Config{})
+	err := Write(out, exec, Config{customTimestamp: new(time.Time).Format(time.RFC3339)})
 	assert.NilError(t, err)
 	golden.Assert(t, out.String(), "junitxml-report.golden")
 }

--- a/internal/junitxml/testdata/junitxml-report.golden
+++ b/internal/junitxml/testdata/junitxml-report.golden
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="0" failures="0" time="0.000000" name="github.com/gotestyourself/gotestyourself/testjson/internal/badmain">
+	<testsuite tests="0" failures="0" time="0.000000" name="github.com/gotestyourself/gotestyourself/testjson/internal/badmain" timestamp="0001-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="go7.7.7"></property>
 		</properties>
@@ -8,7 +8,7 @@
 			<failure message="Failed" type="">sometimes main can exit 2&#xA;FAIL&#x9;github.com/gotestyourself/gotestyourself/testjson/internal/badmain&#x9;0.010s&#xA;</failure>
 		</testcase>
 	</testsuite>
-	<testsuite tests="18" failures="0" time="0.020000" name="github.com/gotestyourself/gotestyourself/testjson/internal/good">
+	<testsuite tests="18" failures="0" time="0.020000" name="github.com/gotestyourself/gotestyourself/testjson/internal/good" timestamp="0001-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="go7.7.7"></property>
 		</properties>
@@ -35,7 +35,7 @@
 		<testcase classname="github.com/gotestyourself/gotestyourself/testjson/internal/good" name="TestParallelTheSecond" time="0.010000"></testcase>
 		<testcase classname="github.com/gotestyourself/gotestyourself/testjson/internal/good" name="TestParallelTheFirst" time="0.010000"></testcase>
 	</testsuite>
-	<testsuite tests="28" failures="4" time="0.020000" name="github.com/gotestyourself/gotestyourself/testjson/internal/stub">
+	<testsuite tests="28" failures="4" time="0.020000" name="github.com/gotestyourself/gotestyourself/testjson/internal/stub" timestamp="0001-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="go7.7.7"></property>
 		</properties>
@@ -80,7 +80,7 @@
 		<testcase classname="github.com/gotestyourself/gotestyourself/testjson/internal/stub" name="TestParallelTheSecond" time="0.010000"></testcase>
 		<testcase classname="github.com/gotestyourself/gotestyourself/testjson/internal/stub" name="TestParallelTheFirst" time="0.010000"></testcase>
 	</testsuite>
-	<testsuite tests="0" failures="0" time="0.000000" name="gotest.tools/gotestsum/internal/empty">
+	<testsuite tests="0" failures="0" time="0.000000" name="gotest.tools/gotestsum/internal/empty" timestamp="0001-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="go7.7.7"></property>
 		</properties>

--- a/testjson/execution.go
+++ b/testjson/execution.go
@@ -564,6 +564,10 @@ func (e *Execution) end() []TestEvent {
 	return result
 }
 
+func (e *Execution) Started() time.Time {
+	return e.started
+}
+
 // newExecution returns a new Execution and records the current time as the
 // time the test execution started.
 func newExecution() *Execution {


### PR DESCRIPTION
The junit schema defines this attribute on the testsuite.
In my case I need to import test results totally separate from the
testing pipeline since these are in two different systems. This
timestamp ensures the result processor puts the results into the right
time frame instead of assuming it just ran.

Fixes #200 