### PR TITLE
Add help command

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,8 +225,8 @@ stdout and stderr output:
 
 * The stdout produced by the script must only contain the `test2json` output, or
   `gotestsum` will fail. If it isn't possible to change the script to avoid
-  non-JSON output, you can use `--ignore-non-json-output-lines` to ignore
-  non-JSON lines and write them to `gotestsum`'s stderr instead.
+  non-JSON output, you can use `--ignore-non-json-output-lines` (added in version 1.7.0)
+  to ignore non-JSON lines and write them to `gotestsum`'s stderr instead.
 * Any stderr produced by the script will be considered an error (this behaviour
   is necessary because package build errors are only reported by writting to
   stderr, not the `test2json` stdout). Any stderr produced by tests is not
@@ -334,15 +334,19 @@ directory will be watched. Use the `--packages` flag to specify a different list
 While in watch mode, pressing some keys will perform an action:
 
 * `r` will run tests for the previous event.
+  Added in version 1.6.1.
 * `d` will run tests for the previous event using `dlv test`, allowing you to 
   debug a test failure using [delve]. A breakpoint will automatically be added at
   the first line of any tests which failed in the previous run. Additional
   breakpoints can be added with [`runtime.Breakpoint`](https://golang.org/pkg/runtime/#Breakpoint)
   or by using the delve command prompt.
+  Added in version 1.6.1.
 * `a` will run tests for all packages, by using `./...` as the package selector.
+  Added in version 1.7.0.
 * `l` will scan the directory list again, and if there are any new directories
   which contain a file with a `.go` extension, they will be added to the watch
   list.
+  Added in version 1.7.0.
 
 Note that [delve] must be installed in order to use debug (`d`).
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -128,6 +128,7 @@ Formats:
 
 Commands:
     tool                    tools for working with test2json output
+    help                    print this help next
 `)
 }
 

--- a/cmd/testdata/gotestsum-help-text
+++ b/cmd/testdata/gotestsum-help-text
@@ -32,3 +32,4 @@ Formats:
 
 Commands:
     tool                    tools for working with test2json output
+    help                    print this help next

--- a/main.go
+++ b/main.go
@@ -27,6 +27,8 @@ func route(args []string) error {
 	name := args[0]
 	next, rest := cmd.Next(args[1:])
 	switch next {
+	case "help", "?":
+		return cmd.Run(name, []string{"--help"})
 	case "tool":
 		return tool.Run(name+" "+next, rest)
 	default:


### PR DESCRIPTION
As suggested here: https://github.com/gotestyourself/gotestsum/issues/207#issuecomment-885975011

`gotestsum help` or `gotestsum ?` will print the help text, which is still available from `gotestsum --help`.

Also adds some "Added in version x.y.z" text to a few of the recently added features in the README