### PR TITLE
Use the event elapsed time for package elapsed

### DIFF
--- a/internal/junitxml/testdata/junitxml-report.golden
+++ b/internal/junitxml/testdata/junitxml-report.golden
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="0" failures="0" time="0.000000" name="github.com/gotestyourself/gotestyourself/testjson/internal/badmain" timestamp="0001-01-01T00:00:00Z">
+	<testsuite tests="0" failures="0" time="0.010000" name="github.com/gotestyourself/gotestyourself/testjson/internal/badmain" timestamp="0001-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="go7.7.7"></property>
 		</properties>
@@ -8,7 +8,7 @@
 			<failure message="Failed" type="">sometimes main can exit 2&#xA;FAIL&#x9;github.com/gotestyourself/gotestyourself/testjson/internal/badmain&#x9;0.010s&#xA;</failure>
 		</testcase>
 	</testsuite>
-	<testsuite tests="18" failures="0" time="0.020000" name="github.com/gotestyourself/gotestyourself/testjson/internal/good" timestamp="0001-01-01T00:00:00Z">
+	<testsuite tests="18" failures="0" time="0.000000" name="github.com/gotestyourself/gotestyourself/testjson/internal/good" timestamp="0001-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="go7.7.7"></property>
 		</properties>
@@ -35,7 +35,7 @@
 		<testcase classname="github.com/gotestyourself/gotestyourself/testjson/internal/good" name="TestParallelTheSecond" time="0.010000"></testcase>
 		<testcase classname="github.com/gotestyourself/gotestyourself/testjson/internal/good" name="TestParallelTheFirst" time="0.010000"></testcase>
 	</testsuite>
-	<testsuite tests="28" failures="4" time="0.020000" name="github.com/gotestyourself/gotestyourself/testjson/internal/stub" timestamp="0001-01-01T00:00:00Z">
+	<testsuite tests="28" failures="4" time="0.011000" name="github.com/gotestyourself/gotestyourself/testjson/internal/stub" timestamp="0001-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="go7.7.7"></property>
 		</properties>
@@ -80,7 +80,7 @@
 		<testcase classname="github.com/gotestyourself/gotestyourself/testjson/internal/stub" name="TestParallelTheSecond" time="0.010000"></testcase>
 		<testcase classname="github.com/gotestyourself/gotestyourself/testjson/internal/stub" name="TestParallelTheFirst" time="0.010000"></testcase>
 	</testsuite>
-	<testsuite tests="0" failures="0" time="0.000000" name="gotest.tools/gotestsum/internal/empty" timestamp="0001-01-01T00:00:00Z">
+	<testsuite tests="0" failures="0" time="0.004000" name="gotest.tools/gotestsum/internal/empty" timestamp="0001-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="go7.7.7"></property>
 		</properties>

--- a/testjson/dotformat_test.go
+++ b/testjson/dotformat_test.go
@@ -105,8 +105,8 @@ func TestFmtDotElapsed(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.expected, func(t *testing.T) {
 			pkg := &Package{
-				cached: tc.cached,
-				Passed: []TestCase{{Elapsed: tc.elapsed}},
+				cached:  tc.cached,
+				elapsed: tc.elapsed,
 			}
 			actual := fmtDotElapsed(pkg)
 			assert.Check(t, cmp.Equal(utf8.RuneCountInString(actual), 7))

--- a/testjson/execution_test.go
+++ b/testjson/execution_test.go
@@ -12,22 +12,6 @@ import (
 	"gotest.tools/v3/golden"
 )
 
-func TestPackage_Elapsed(t *testing.T) {
-	pkg := &Package{
-		Failed: []TestCase{
-			{Elapsed: 300 * time.Millisecond},
-		},
-		Passed: []TestCase{
-			{Elapsed: 200 * time.Millisecond},
-			{Elapsed: 2500 * time.Millisecond},
-		},
-		Skipped: []TestCase{
-			{Elapsed: 100 * time.Millisecond},
-		},
-	}
-	assert.Equal(t, pkg.Elapsed(), 3100*time.Millisecond)
-}
-
 func TestExecution_Add_PackageCoverage(t *testing.T) {
 	exec := newExecution()
 	exec.add(TestEvent{
@@ -144,7 +128,7 @@ func TestPackage_AddEvent(t *testing.T) {
 		{
 			name:     "package failed",
 			event:    `{"Action":"fail","Package":"gotest.tools/testing","Elapsed":0.012}`,
-			expected: Package{action: ActionFail},
+			expected: Package{action: ActionFail, elapsed: 12 * time.Millisecond},
 		},
 		{
 			name:  "package is cached",
@@ -157,7 +141,7 @@ func TestPackage_AddEvent(t *testing.T) {
 		{
 			name:     "package pass",
 			event:    `{"Action":"pass","Package":"gotest.tools/testing","Elapsed":0.012}`,
-			expected: Package{action: ActionPass},
+			expected: Package{action: ActionPass, elapsed: 12 * time.Millisecond},
 		},
 	}
 

--- a/testjson/format_test.go
+++ b/testjson/format_test.go
@@ -105,15 +105,18 @@ var expectedExecution = &Execution{
 				{Test: "TestSkipped"},
 				{Test: "TestSkippedWitLog"},
 			},
+			elapsed: 11 * time.Millisecond,
 			action:  ActionFail,
 			running: map[string]TestCase{},
 		},
 		"github.com/gotestyourself/gotestyourself/testjson/internal/badmain": {
 			action:  ActionFail,
 			running: map[string]TestCase{},
+			elapsed: 10 * time.Millisecond,
 		},
 		"gotest.tools/gotestsum/internal/empty": {
-			action: ActionPass,
+			action:  ActionPass,
+			elapsed: 4 * time.Millisecond,
 		},
 	},
 }
@@ -224,6 +227,7 @@ var expectedCoverageExecution = &Execution{
 				{Test: "TestSkipped"},
 				{Test: "TestSkippedWitLog"},
 			},
+			elapsed:  12 * time.Millisecond,
 			action:   ActionPass,
 			coverage: "coverage: 0.0% of statements",
 			running:  map[string]TestCase{},
@@ -240,6 +244,7 @@ var expectedCoverageExecution = &Execution{
 				{Test: "TestSkipped"},
 				{Test: "TestSkippedWitLog"},
 			},
+			elapsed:  11 * time.Millisecond,
 			action:   ActionFail,
 			coverage: "coverage: 0.0% of statements",
 			running:  map[string]TestCase{},
@@ -247,6 +252,7 @@ var expectedCoverageExecution = &Execution{
 		"gotest.tools/gotestsum/testjson/internal/badmain": {
 			action:  ActionFail,
 			running: map[string]TestCase{},
+			elapsed: time.Millisecond,
 		},
 	},
 }

--- a/testjson/testdata/dots-format.out
+++ b/testjson/testdata/dots-format.out
@@ -1,712 +1,712 @@
 
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
 
  0 tests, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good 
 
  1 tests, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good ·
 
  1 tests, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good ·
 
  2 tests, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good ··
 
  2 tests, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good ··
 
  3 tests, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good ···
 
  3 tests, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good ···
 
  4 tests, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good ···↷
 
  4 tests, 1 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good ···↷
 
  5 tests, 1 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good ···↷↷
 
  5 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good ···↷↷
 
  6 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  6 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  7 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  7 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  8 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  8 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  9 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  9 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  10 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  11 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  12 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  13 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  14 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  15 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  16 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  17 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good ···↷↷·
 
  18 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good ···↷↷··
 
  18 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good ···↷↷···
 
  18 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good ···↷↷····
 
  18 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good ···↷↷·····
 
  18 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good ···↷↷······
 
  18 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good ···↷↷·······
 
  18 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good ···↷↷········
 
  18 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good ···↷↷·········
 
  18 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good ···↷↷··········
 
  18 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good ···↷↷··········
 
  18 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good ···↷↷··········
 
  18 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good ···↷↷··········
 
  18 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
        testjson/internal/good ···↷↷···········
 
  18 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
-  10ms testjson/internal/good ···↷↷············
+  10ms testjson/internal/badmain 
+       testjson/internal/good ···↷↷············
 
  18 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
-  20ms testjson/internal/good ···↷↷·············
+  10ms testjson/internal/badmain 
+       testjson/internal/good ···↷↷·············
 
  18 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
 
  18 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub 
 
  19 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ·
 
  19 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ·
 
  20 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ··
 
  20 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ··
 
  21 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···
 
  21 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···
 
  22 tests, 2 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷
 
  22 tests, 3 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷
 
  23 tests, 3 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷
 
  23 tests, 4 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷
 
  24 tests, 4 skipped, 1 failure, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖
 
  24 tests, 4 skipped, 2 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖
 
  25 tests, 4 skipped, 2 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·
 
  25 tests, 4 skipped, 2 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·
 
  26 tests, 4 skipped, 2 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  26 tests, 4 skipped, 3 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  27 tests, 4 skipped, 3 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  27 tests, 4 skipped, 3 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  28 tests, 4 skipped, 3 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  28 tests, 4 skipped, 3 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  29 tests, 4 skipped, 3 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  29 tests, 4 skipped, 3 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  30 tests, 4 skipped, 3 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  31 tests, 4 skipped, 3 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  32 tests, 4 skipped, 3 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  33 tests, 4 skipped, 3 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  34 tests, 4 skipped, 3 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  35 tests, 4 skipped, 3 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  36 tests, 4 skipped, 3 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖
 
  37 tests, 4 skipped, 3 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖·
 
  37 tests, 4 skipped, 3 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖··
 
  37 tests, 4 skipped, 3 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖···
 
  37 tests, 4 skipped, 3 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····
 
  37 tests, 4 skipped, 3 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖
 
  37 tests, 4 skipped, 4 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖·
 
  37 tests, 4 skipped, 4 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··
 
  37 tests, 4 skipped, 4 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖
 
  37 tests, 4 skipped, 5 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖
 
  38 tests, 4 skipped, 5 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖
 
  39 tests, 4 skipped, 5 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖
 
  40 tests, 4 skipped, 5 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖
 
  41 tests, 4 skipped, 5 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖
 
  42 tests, 4 skipped, 5 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖
 
  43 tests, 4 skipped, 5 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖
 
  44 tests, 4 skipped, 5 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖
 
  45 tests, 4 skipped, 5 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖
 
  46 tests, 4 skipped, 5 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖·
 
  46 tests, 4 skipped, 5 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖··
 
  46 tests, 4 skipped, 5 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖···
 
  46 tests, 4 skipped, 5 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖····
 
  46 tests, 4 skipped, 5 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖·····
 
  46 tests, 4 skipped, 5 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖······
 
  46 tests, 4 skipped, 5 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖·······
 
  46 tests, 4 skipped, 5 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖········
 
  46 tests, 4 skipped, 5 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖·········
 
  46 tests, 4 skipped, 5 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖·········
 
  46 tests, 4 skipped, 5 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖·········
 
  46 tests, 4 skipped, 5 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖·········
 
  46 tests, 4 skipped, 5 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
        testjson/internal/stub ···↷↷✖·✖····✖··✖··········
 
  46 tests, 4 skipped, 5 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
-  10ms testjson/internal/stub ···↷↷✖·✖····✖··✖···········
+       testjson/internal/stub ···↷↷✖·✖····✖··✖···········
 
  46 tests, 4 skipped, 5 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/stub ···↷↷✖·✖····✖··✖············
+       testjson/internal/stub ···↷↷✖·✖····✖··✖············
 
  46 tests, 4 skipped, 5 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/stub ···↷↷✖·✖····✖··✖············
+  11ms testjson/internal/stub ···↷↷✖·✖····✖··✖············
 
  46 tests, 4 skipped, 5 failures, 1 error
 [1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
 
-       testjson/internal/badmain 
+  10ms testjson/internal/badmain 
     🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/stub ···↷↷✖·✖····✖··✖············
-       gotest.tools/gotestsum/internal/empty 
+  11ms testjson/internal/stub ···↷↷✖·✖····✖··✖············
+   4ms gotest.tools/gotestsum/internal/empty 
 
  46 tests, 4 skipped, 5 failures, 1 error


### PR DESCRIPTION
Fixes #213

I'm not sure why I implemented it as the sum of test elapsed times. From what I can tell the package pass/fail event has always had the proper elapsed time. 

Using the time reported from the event should also be more accurate and include all the elapsed time from tests, as well as any time spent in `init`, `TestMain`,  or static declarations.