### PR TITLE
update 'go get' idirective to 'go install'

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See [documentation](#documentation).
 ## Install
 
 Download a binary from [releases](https://github.com/gotestyourself/gotestsum/releases), or build from
-source with `go get gotest.tools/gotestsum`.
+source with `go install gotest.tools/gotestsum@latest`. With `go` version before 1.17, use `go get gotest.tools/gotestsum`.
 
 ## Demo
 A demonstration of three `--format` options.


### PR DESCRIPTION
PR modifies the installation instructions to account for the deprecation of the `go get` method:
https://go.dev/doc/go-get-install-deprecation.