### PR TITLE
fix: remove deprecated linters from golanci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,7 @@ linters-settings:
 issues:
   exclude-use-default: false
   exclude-rules:
-    - linters: [golint]
+    - linters: [revive]
       text: 'should have comment .*or be unexported'
     - linters: [stylecheck]
       text: 'ST1000: at least one file in a package should have a package comment'
@@ -33,7 +33,6 @@ linters:
     - gocyclo
     - gofmt
     - goimports
-    - golint
     - gosimple
     - govet
     - ineffassign
@@ -42,6 +41,7 @@ linters:
     - misspell
     - nakedret
     - prealloc
+    - revive
     - staticcheck
     - structcheck
     - stylecheck

--- a/internal/dotwriter/writer_posix.go
+++ b/internal/dotwriter/writer_posix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package dotwriter

--- a/internal/filewatcher/term_unix.go
+++ b/internal/filewatcher/term_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package filewatcher


### PR DESCRIPTION
golangci-lint passes like before.