### PR TITLE
Instructions to compile `test2json` without local go

### DIFF
--- a/docs/running-without-go.md
+++ b/docs/running-without-go.md
@@ -3,15 +3,16 @@
 `gotestsum` may be run without Go as long as the package to be tested has
 already been compiled using `go test -c`, and the `test2json` tool is available.
 
-The `test2json` tool can be compiled from the Go source tree:
+The `test2json` tool can be compiled from the Go source tree so that it can be distributed to the environment that needs it.
 
 ```sh
-export GOVERSION=1.13.5
-curl -Lo go.zip "https://github.com/golang/go/archive/go${GOVERSION}.zip"
-unzip go.zip
-rm -f go.zip
-cd go-go${GOVERSION}/src/cmd/test2json/
-env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" .
+GOVERSION=1.17.6
+OS=$(uname -s | sed 's/.*/\L&/')
+mkdir -p gopath
+GOPATH=$(realpath gopath)
+HOME=$(realpath ./)
+curl -L --silent https://go.dev/dl/go${GOVERSION}.${OS}-amd64.tar.gz | tar xz -C ./
+env HOME=$HOME GOOS=linux GOARCH=amd64 CGO_ENABLED=0 GOPATH=$GOPATH ./go/bin/go build -o test2json -ldflags="-s -w" cmd/test2json
 mv test2json /usr/local/bin/test2json
 ```
 
@@ -27,4 +28,3 @@ Example: running without a Go installation
 export GOVERSION=1.13
 gotestsum --raw-command -- test2json -t -p pkgname ./binary.test -test.v
 ```
-


### PR DESCRIPTION
With the current instructions you actually need a local go installation. Even if the go source is downloaded, a go binary is needed to compile test2json, even if it's a different version than the `test2json` one.

This PR adds instructions to download a temporary go binary, compile test2json from it and delete it.