### PR TITLE
Pass stdin to go test

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,11 @@ stdout and stderr output:
   stderr, not the `test2json` stdout). Any stderr produced by tests is not
   considered an error (it will be in the `test2json` stdout).
 
+**Example: accept intput from stdin**
+```
+cat out.json | gotestsum --raw-command -- cat
+```
+
 **Example: run tests with profiling enabled**
 
 Using a `profile.sh` script like this:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -356,6 +356,7 @@ func startGoTest(ctx context.Context, args []string) (*proc, error) {
 	}
 
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	cmd.Stdin = os.Stdin
 	p := proc{cmd: cmd}
 	log.Debugf("exec: %s", cmd.Args)
 	var err error


### PR DESCRIPTION
It may be useful to pipe the `go test` JSON to `gotestsum`. There are a few ways in which this could be achieved:

1. Passing stdin to `testjson.ScanConfig` seems the most sensible, but it may be complicated and may cause unintended side effects. For instance, assuming `gotestsum` were to contextually switch between using stdin and `go test`, existing invocations of `gotestsum` where data is being piped would no longer work. Providing a new flag to opt-in may be helpful? Maybe a sub-command?

2. (This PR) Passing stdin to `--raw-command` allows stdin to be piped to stdout via use of a tool like `cat`.

---

Given the changes included in this PR, `gotestsum` can read `go test` JSON via stdin with:

```sh
cat out.json | gotestsum --raw-command -- cat
```

This may be useful when the JSON is generated via other tools (i.e Bazel). For example:

```sh
bazel test //... |& go tool test2json | gotestsum --raw-command -- cat
# or
bazel test //... |& gotestsum --raw-command -- go tool test2json
```

What do you think?