### PR TITLE
Ensure we still rerun tests when there are warnings

### DIFF
--- a/cmd/main_e2e_test.go
+++ b/cmd/main_e2e_test.go
@@ -248,3 +248,29 @@ func TestE2E_MaxFails_EndTestRun(t *testing.T) {
 	)
 	golden.Assert(t, out, "e2e/expected/"+t.Name())
 }
+
+func TestE2E_IgnoresWarnings(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for short run")
+	}
+
+	flags, opts := setupFlags("gotestsum")
+	args := []string{"--rerun-fails=1", "--packages=./testdata/e2e/ignore_warnings/", "--", "-tags=testdata",
+		"-cover", "-coverpkg=github.com/pkg/errors"}
+	assert.NilError(t, flags.Parse(args))
+	opts.args = flags.Args()
+
+	bufStdout := new(bytes.Buffer)
+	opts.stdout = bufStdout
+	bufStderr := new(bytes.Buffer)
+	opts.stderr = bufStderr
+
+	err := run(opts)
+	assert.Error(t, err, "exit status 1")
+	out := text.ProcessLines(t, bufStdout,
+		text.OpRemoveSummaryLineElapsedTime,
+		text.OpRemoveTestElapsedTime,
+		filepath.ToSlash, // for windows
+	)
+	golden.Assert(t, out, "e2e/expected/"+t.Name())
+}

--- a/cmd/main_e2e_test.go
+++ b/cmd/main_e2e_test.go
@@ -255,8 +255,12 @@ func TestE2E_IgnoresWarnings(t *testing.T) {
 	}
 
 	flags, opts := setupFlags("gotestsum")
-	args := []string{"--rerun-fails=1", "--packages=./testdata/e2e/ignore_warnings/", "--", "-tags=testdata",
-		"-cover", "-coverpkg=github.com/pkg/errors"}
+	args := []string{
+		"--rerun-fails=1",
+		"--packages=./testdata/e2e/ignore_warnings/",
+		"--format=testname",
+		"--", "-tags=testdata", "-cover", "-coverpkg=github.com/pkg/errors",
+	}
 	assert.NilError(t, flags.Parse(args))
 	opts.args = flags.Args()
 

--- a/cmd/testdata/e2e/expected/TestE2E_IgnoresWarnings
+++ b/cmd/testdata/e2e/expected/TestE2E_IgnoresWarnings
@@ -1,0 +1,12 @@
+✖  cmd/testdata/e2e/ignore_warnings
+
+DONE 1 tests, 1 failure
+
+✖  cmd/testdata/e2e/ignore_warnings
+
+=== Failed
+=== FAIL: cmd/testdata/e2e/ignore_warnings TestIgnoreWarnings
+
+=== FAIL: cmd/testdata/e2e/ignore_warnings TestIgnoreWarnings (re-run 1)
+
+DONE 2 runs, 2 tests, 2 failures

--- a/cmd/testdata/e2e/expected/TestE2E_IgnoresWarnings
+++ b/cmd/testdata/e2e/expected/TestE2E_IgnoresWarnings
@@ -1,8 +1,16 @@
-✖  cmd/testdata/e2e/ignore_warnings
+=== RUN   TestIgnoreWarnings
+--- FAIL: TestIgnoreWarnings
+FAIL cmd/testdata/e2e/ignore_warnings.TestIgnoreWarnings
+coverage: [no statements]
+FAIL cmd/testdata/e2e/ignore_warnings
 
 DONE 1 tests, 1 failure
 
-✖  cmd/testdata/e2e/ignore_warnings
+=== RUN   TestIgnoreWarnings
+--- FAIL: TestIgnoreWarnings
+FAIL cmd/testdata/e2e/ignore_warnings.TestIgnoreWarnings (re-run 1)
+coverage: [no statements]
+FAIL cmd/testdata/e2e/ignore_warnings
 
 === Failed
 === FAIL: cmd/testdata/e2e/ignore_warnings TestIgnoreWarnings

--- a/cmd/testdata/e2e/ignore_warnings/ignore_warnings.go
+++ b/cmd/testdata/e2e/ignore_warnings/ignore_warnings.go
@@ -1,0 +1,1 @@
+package ignore_warnings

--- a/cmd/testdata/e2e/ignore_warnings/ignore_warnings_test.go
+++ b/cmd/testdata/e2e/ignore_warnings/ignore_warnings_test.go
@@ -1,0 +1,7 @@
+package ignore_warnings
+
+import "testing"
+
+func TestIgnoreWarnings(t *testing.T) {
+	t.Fail()
+}

--- a/testjson/execution.go
+++ b/testjson/execution.go
@@ -697,6 +697,9 @@ func readStderr(config ScanConfig, execution *Execution) error {
 		if isGoModuleOutput(line) {
 			continue
 		}
+		if strings.HasPrefix(line, "warning:") {
+			continue
+		}
 		execution.addError(line)
 	}
 	if err := scanner.Err(); err != nil {


### PR DESCRIPTION
Proposal for skipping over warnings.

Elapsed times in golden files are causing this to fail.  It's also a pretty heavy-weight test for such a small change so maybe we should test this some other way.

Fixes #232 