### PR TITLE
Fix the build on aix

### DIFF
--- a/internal/filewatcher/term_aix.go
+++ b/internal/filewatcher/term_aix.go
@@ -1,0 +1,9 @@
+//go:build aix
+// +build aix
+
+package filewatcher
+
+import "golang.org/x/sys/unix"
+
+const tcGet = unix.TCGETA
+const tcSet = unix.TCSETA

--- a/internal/filewatcher/term_bsd.go
+++ b/internal/filewatcher/term_bsd.go
@@ -1,3 +1,4 @@
+//go:build darwin || dragonfly || freebsd || netbsd || openbsd
 // +build darwin dragonfly freebsd netbsd openbsd
 
 package filewatcher

--- a/internal/filewatcher/term_unix.go
+++ b/internal/filewatcher/term_unix.go
@@ -1,5 +1,5 @@
-//go:build !windows
-// +build !windows
+//go:build !windows && !aix
+// +build !windows,!aix
 
 package filewatcher
 

--- a/internal/filewatcher/watch.go
+++ b/internal/filewatcher/watch.go
@@ -1,3 +1,6 @@
+//go:build !aix
+// +build !aix
+
 package filewatcher
 
 import (

--- a/internal/filewatcher/watch_unsupported.go
+++ b/internal/filewatcher/watch_unsupported.go
@@ -1,0 +1,18 @@
+//go:build aix
+// +build aix
+
+package filewatcher
+
+import (
+	"fmt"
+	"runtime"
+)
+
+type Event struct {
+	PkgPath string
+	Debug   bool
+}
+
+func Watch(dirs []string, run func(Event) error) error {
+	return fmt.Errorf("file watching is not supported on %v/%v", runtime.GOOS, runtime.GOARCH)
+}


### PR DESCRIPTION
Fixes #244

Cross compiling worked:
```
GOOS=aix GOARCH=ppc64 go build .
```

Everything except for the `--watch` flag should work, but I can't test it.