### PR TITLE
parse outputs for garbled passes to avoid spurious failures

### DIFF
--- a/testjson/execution.go
+++ b/testjson/execution.go
@@ -81,7 +81,6 @@ type Package struct {
 	Total         int
 	running       map[string]TestCase
 	passedOutputs map[string]TestCase
-	failedOutputs map[string]TestCase
 	Failed        []TestCase
 	Skipped       []TestCase
 	Passed        []TestCase
@@ -249,6 +248,7 @@ func (p *Package) end() []TestEvent {
 			continue
 		} else if passedTC, ok := p.passedOutputs[k]; ok {
 			// this passed but test2json failed to parse it and record a "pass" action
+			p.removeOutput(tc.ID)
 			p.Passed = append(p.Passed, passedTC)
 			result = append(result, TestEvent{
 				Action:  ActionPass,
@@ -594,6 +594,7 @@ func (e *Execution) end() []TestEvent {
 	var result []TestEvent // nolint: prealloc
 	for _, pkg := range e.packages {
 		result = append(result, pkg.end()...)
+		pkg.passedOutputs = make(map[string]TestCase)
 	}
 	return result
 }

--- a/testjson/execution.go
+++ b/testjson/execution.go
@@ -405,16 +405,16 @@ func (p *Package) addTestEvent(event TestEvent) {
 	case ActionOutput, ActionBench:
 		tc := p.running[event.Test]
 		p.addOutput(tc.ID, event.Output)
-		passFailRegex, err := regexp.Compile(fmt.Sprintf(`(PASS|FAIL): %s \((.*)s\)`, event.Test))
+		passFailRegex, err := regexp.Compile(fmt.Sprintf(`PASS: %s \((.*)s\)`, event.Test))
 		if err != nil {
 			fmt.Println("failed to parse output for pass/fail")
 			return
 		}
 		passesOrFails := passFailRegex.FindStringSubmatch(event.Output)
-		if len(passesOrFails) == 3 && passesOrFails[1] == "PASS" {
-			parsedDuration, err := strconv.ParseFloat(passesOrFails[2], 64)
+		if len(passesOrFails) == 2 {
+			parsedDuration, err := strconv.ParseFloat(passesOrFails[1], 64)
 			if err != nil {
-				fmt.Printf("failed to parse duration %s\n", passesOrFails[2])
+				fmt.Printf("failed to parse duration %s\n", passesOrFails[1])
 				tc.Elapsed = neverFinished
 			} else {
 				tc.Elapsed = elapsedDuration(parsedDuration)

--- a/testjson/execution_test.go
+++ b/testjson/execution_test.go
@@ -180,7 +180,8 @@ func TestScanOutput_WithMissingEvents(t *testing.T) {
 		{Action: ActionPass},
 		{Action: ActionFail, Test: "TestMissing", Elapsed: -1},
 		{Action: ActionFail, Test: "TestMissing/a", Elapsed: -1},
-		{Action: ActionFail, Test: "TestMissingEvent", Elapsed: -1},
+		// we should parse the success from the output despite the missing pass event
+		{Action: ActionPass, Test: "TestMissingEvent", Elapsed: 0},
 		{Action: ActionFail, Test: "TestFailed/a", Elapsed: -1},
 		{Action: ActionFail, Test: "TestFailed/a/sub", Elapsed: -1},
 	}

--- a/testjson/execution_test.go
+++ b/testjson/execution_test.go
@@ -217,6 +217,24 @@ func TestScanOutput_WithNonJSONLines(t *testing.T) {
 	}
 }
 
+func TestScanOutput_WithNewlineGarbledPass(t *testing.T) {
+	source := golden.Get(t, "go-test-json-newline-garbled.out")
+	handler := &captureHandler{}
+	cfg := ScanConfig{
+		Stdout:  bytes.NewReader(source),
+		Handler: handler,
+	}
+	_, err := ScanTestOutput(cfg)
+	assert.NilError(t, err)
+
+	expected := TestEvent{Action: ActionPass, Test: "TestPassed", Elapsed: 0.18}
+	assert.Assert(t, len(handler.events) > 2) // run, outcome, and some output
+	lastEvent := handler.events[len(handler.events)-1]
+	assert.Equal(t, expected.Test, lastEvent.Test)
+	assert.Equal(t, expected.Action, lastEvent.Action)
+	assert.Equal(t, expected.Elapsed, lastEvent.Elapsed)
+}
+
 type captureHandler struct {
 	events []TestEvent
 	errs   []string

--- a/testjson/testdata/go-test-json-newline-garbled.out
+++ b/testjson/testdata/go-test-json-newline-garbled.out
@@ -1,0 +1,4 @@
+{"Time":"2021-04-17T14:33:35.167978423Z","Action":"run","Package":"gotest.tools/testing","Test":"TestPassed"}
+{"Time":"2021-04-17T14:33:35.167999152Z","Action":"output","Package":"gotest.tools/testing","Test":"TestPassed","Output":"=== RUN   TestPassed\n"}
+{"Time":"2021-04-17T14:33:35.168007043Z","Action":"output","Package":"gotest.tools/testing","Test":"TestPassed","Output":"\tat ExampleStackFrame (/example.go:17)\n"}
+{"Time":"2021-04-17T14:33:35.168007043Z","Action":"output","Package":"gotest.tools/testing","Test":"TestPassed","Output":"[example.go--- PASS: TestPassed (0.18s)\n"}


### PR DESCRIPTION
Implements [this suggestion](https://github.com/gotestyourself/gotestsum/issues/141#issuecomment-695852536) -- updates the execution to search output events for the `PASS` output string. It will then count those as pass events (if no true pass event is encountered). As per https://github.com/golang/go/issues/26325, `test2json` occasionally has issues with interleaving stdout logs and test result logs, leading to output lines like
```
"Output":"[example.go--- PASS: TestExample (0.08s)\n"
```
The extra text in the output breaks `test2json`'s ability to detect that this is in fact a pass, and as a result we get neither a `pass` nor ` fail` event in the output json. With this change, we will still be able to count this as a pass.