### PR TITLE
Add tool ci-matrix

### DIFF
--- a/cmd/tool/matrix/matrix.go
+++ b/cmd/tool/matrix/matrix.go
@@ -1,0 +1,250 @@
+package matrix
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/dnephin/pflag"
+	"gotest.tools/gotestsum/internal/log"
+	"gotest.tools/gotestsum/testjson"
+)
+
+func Run(name string, args []string) error {
+	flags, opts := setupFlags(name)
+	switch err := flags.Parse(args); {
+	case err == pflag.ErrHelp:
+		return nil
+	case err != nil:
+		usage(os.Stderr, name, flags)
+		return err
+	}
+	return run(*opts)
+}
+
+type options struct {
+	maxAge            time.Duration
+	buckets           uint
+	timingReportsPath string
+	debug             bool
+}
+
+func setupFlags(name string) (*pflag.FlagSet, *options) {
+	opts := &options{}
+	flags := pflag.NewFlagSet(name, pflag.ContinueOnError)
+	flags.SetInterspersed(false)
+	flags.Usage = func() {
+		usage(os.Stdout, name, flags)
+	}
+	flags.DurationVar(&opts.maxAge, "max-age", 7*24*time.Hour,
+		"Timing reports older than max age will be deleted")
+	flags.UintVar(&opts.buckets, "buckets", 4,
+		"number of parallel buckets to create in the test matrix")
+	flags.StringVar(&opts.timingReportsPath, "dir", "",
+		"path to directory that contains jsonfile timing reports")
+	flags.BoolVar(&opts.debug, "debug", false,
+		"enable debug logging.")
+	return flags, opts
+}
+
+func usage(out io.Writer, name string, flags *pflag.FlagSet) {
+	fmt.Fprintf(out, `Usage:
+    %[1]s [flags]
+
+Flags:
+`, name)
+	flags.SetOutput(out)
+	flags.PrintDefaults()
+}
+
+func run(opts options) error {
+	log.SetLevel(log.InfoLevel)
+	if opts.debug {
+		log.SetLevel(log.DebugLevel)
+	}
+	if opts.buckets < 2 {
+		return fmt.Errorf("--buckets must be atleast 2")
+	}
+	if opts.timingReportsPath == "" {
+		return fmt.Errorf("--dir is required")
+	}
+
+	pkgs, err := readPackages(os.Stdin)
+	if err != nil {
+		return fmt.Errorf("failed to read packages from stdin: %v", err)
+	}
+
+	files, err := readAndPruneTimingReports(opts)
+	if err != nil {
+		return fmt.Errorf("failed to read or delete timing reports: %v", err)
+	}
+	defer closeFiles(files)
+
+	pkgTiming, err := packageTiming(files)
+	if err != nil {
+		return err
+	}
+
+	buckets := bucketPackages(packagePercentile(pkgTiming), pkgs, opts.buckets)
+	return writeBuckets(buckets)
+}
+
+func readPackages(stdin io.Reader) ([]string, error) {
+	var packages []string
+	scan := bufio.NewScanner(stdin)
+	for scan.Scan() {
+		packages = append(packages, scan.Text())
+	}
+	return packages, scan.Err()
+}
+
+func readAndPruneTimingReports(opts options) ([]*os.File, error) {
+	entries, err := os.ReadDir(opts.timingReportsPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var files []*os.File
+	for _, entry := range entries {
+		if entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+
+		fh, err := os.Open(filepath.Join(opts.timingReportsPath, entry.Name()))
+		if err != nil {
+			return nil, err
+		}
+
+		event, err := parseEvent(fh)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read first event from %v: %v", fh.Name(), err)
+		}
+
+		age := time.Since(event.Time)
+		if age < opts.maxAge {
+			if _, err := fh.Seek(0, io.SeekStart); err != nil {
+				return nil, fmt.Errorf("failed to reset file: %v", err)
+			}
+			files = append(files, fh)
+			continue
+		}
+
+		log.Infof("Removing %v because it is from %v", fh.Name(), event.Time.Format(time.RFC1123))
+		_ = fh.Close()
+		if err := os.Remove(fh.Name()); err != nil {
+			return nil, err
+		}
+	}
+
+	log.Infof("Found %v timing reports in %v", len(files), opts.timingReportsPath)
+	return files, nil
+}
+
+func parseEvent(reader io.Reader) (testjson.TestEvent, error) {
+	event := testjson.TestEvent{}
+	err := json.NewDecoder(reader).Decode(&event)
+	return event, err
+}
+
+func packageTiming(files []*os.File) (map[string][]time.Duration, error) {
+	timing := make(map[string][]time.Duration)
+	for _, fh := range files {
+		exec, err := testjson.ScanTestOutput(testjson.ScanConfig{Stdout: fh})
+		if err != nil {
+			return nil, fmt.Errorf("failed to read events from %v: %v", fh.Name(), err)
+		}
+
+		for _, pkg := range exec.Packages() {
+			log.Debugf("package elapsed time %v %v", pkg, exec.Package(pkg).Elapsed())
+			timing[pkg] = append(timing[pkg], exec.Package(pkg).Elapsed())
+		}
+	}
+	return timing, nil
+}
+
+func packagePercentile(timing map[string][]time.Duration) map[string]time.Duration {
+	result := make(map[string]time.Duration)
+	for pkg, times := range timing {
+		l := len(times)
+		if l == 0 {
+			result[pkg] = 0
+			continue
+		}
+
+		sort.Slice(times, func(i, j int) bool {
+			return times[i] < times[j]
+		})
+
+		r := int(math.Ceil(0.85 * float64(l)))
+		if r == 0 {
+			result[pkg] = times[0]
+			continue
+		}
+		result[pkg] = times[r-1]
+	}
+	return result
+}
+
+func closeFiles(files []*os.File) {
+	for _, fh := range files {
+		_ = fh.Close()
+	}
+}
+
+func bucketPackages(timing map[string]time.Duration, packages []string, n uint) []bucket {
+	sort.SliceStable(packages, func(i, j int) bool {
+		return timing[packages[i]] >= timing[packages[j]]
+	})
+
+	buckets := make([]bucket, n)
+	for _, pkg := range packages {
+		i := minBucket(buckets)
+		buckets[i].Total += timing[pkg]
+		buckets[i].Packages = append(buckets[i].Packages, pkg)
+		log.Debugf("adding %v (%v) to bucket %v with total %v",
+			pkg, timing[pkg], i, buckets[i].Total)
+	}
+	return buckets
+}
+
+func minBucket(buckets []bucket) int {
+	var n int
+	var min time.Duration = -1
+	for i, b := range buckets {
+		switch {
+		case min < 0 || b.Total < min:
+			min = b.Total
+			n = i
+		case b.Total == min && len(buckets[i].Packages) < len(buckets[n].Packages):
+			n = i
+		}
+	}
+	return n
+}
+
+type bucket struct {
+	Total    time.Duration
+	Packages []string
+}
+
+func writeBuckets(buckets []bucket) error {
+	out := make(map[int]string)
+	for i, bucket := range buckets {
+		out[i] = strings.Join(bucket.Packages, " ")
+	}
+
+	raw, err := json.Marshal(out)
+	if err != nil {
+		return fmt.Errorf("failed to json encode output: %v", err)
+	}
+	log.Debugf(string(raw))
+	fmt.Println(string(raw))
+	return nil
+}

--- a/cmd/tool/matrix/matrix.go
+++ b/cmd/tool/matrix/matrix.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/dnephin/pflag"
@@ -253,10 +254,10 @@ type matrix struct {
 }
 
 type Partition struct {
-	ID               int      `json:"id"`
-	EstimatedRuntime string   `json:"estimatedRuntime"`
-	Packages         []string `json:"packages"`
-	Description      string   `json:"description"`
+	ID               int    `json:"id"`
+	EstimatedRuntime string `json:"estimatedRuntime"`
+	Packages         string `json:"packages"`
+	Description      string `json:"description"`
 }
 
 func writeMatrix(out io.Writer, buckets []bucket) error {
@@ -265,15 +266,15 @@ func writeMatrix(out io.Writer, buckets []bucket) error {
 		p := Partition{
 			ID:               i,
 			EstimatedRuntime: bucket.Total.String(),
-			Packages:         bucket.Packages,
+			Packages:         strings.Join(bucket.Packages, " "),
 		}
-		if len(p.Packages) > 0 {
+		if len(bucket.Packages) > 0 {
 			var extra string
-			if len(p.Packages) > 1 {
-				extra = fmt.Sprintf(" and %d others", len(p.Packages)-1)
+			if len(bucket.Packages) > 1 {
+				extra = fmt.Sprintf(" and %d others", len(bucket.Packages)-1)
 			}
 			p.Description = fmt.Sprintf("partition %d - package %v%v",
-				p.ID, testjson.RelativePackagePath(p.Packages[0]), extra)
+				p.ID, testjson.RelativePackagePath(bucket.Packages[0]), extra)
 		}
 
 		m.Include[i] = p

--- a/cmd/tool/matrix/matrix.go
+++ b/cmd/tool/matrix/matrix.go
@@ -64,9 +64,8 @@ func usage(out io.Writer, name string, flags *pflag.FlagSet) {
 Read a list of packages from stdin and output a GitHub Actions matrix strategy
 that splits the packages by previous run times to minimize overall CI runtime.
 
-    echo -n "::set-output name=matrix::"
-    go list ./... | \
-        %[1]s --timing-files ./*.log --partitions 4
+    echo -n "matrix=" >> $GITHUB_OUTPUT
+    go list ./... | %[1]s --timing-files ./*.log --partitions 4 >> $GITHUB_OUTPUT
 
 The output of the command is a JSON object that can be used as the matrix
 strategy for a test job.

--- a/cmd/tool/matrix/matrix.go
+++ b/cmd/tool/matrix/matrix.go
@@ -177,7 +177,6 @@ func packageTiming(files []*os.File) (map[string][]time.Duration, error) {
 		}
 
 		for _, pkg := range exec.Packages() {
-			log.Debugf("package elapsed time %v %v", pkg, exec.Package(pkg).Elapsed())
 			timing[pkg] = append(timing[pkg], exec.Package(pkg).Elapsed())
 		}
 	}
@@ -254,10 +253,10 @@ type matrix struct {
 }
 
 type Partition struct {
-	ID               int           `json:"id"`
-	EstimatedRuntime time.Duration `json:"estimatedRuntime"`
-	Packages         []string      `json:"packages"`
-	Description      string        `json:"description"`
+	ID               int      `json:"id"`
+	EstimatedRuntime string   `json:"estimatedRuntime"`
+	Packages         []string `json:"packages"`
+	Description      string   `json:"description"`
 }
 
 func writeMatrix(out io.Writer, buckets []bucket) error {
@@ -265,7 +264,7 @@ func writeMatrix(out io.Writer, buckets []bucket) error {
 	for i, bucket := range buckets {
 		p := Partition{
 			ID:               i,
-			EstimatedRuntime: bucket.Total,
+			EstimatedRuntime: bucket.Total.String(),
 			Packages:         bucket.Packages,
 		}
 		if len(p.Packages) > 0 {
@@ -273,10 +272,8 @@ func writeMatrix(out io.Writer, buckets []bucket) error {
 			if len(p.Packages) > 1 {
 				extra = fmt.Sprintf(" and %d others", len(p.Packages)-1)
 			}
-			p.Description = fmt.Sprintf("package %v%v (%v)",
-				testjson.RelativePackagePath(p.Packages[0]),
-				extra,
-				p.EstimatedRuntime)
+			p.Description = fmt.Sprintf("partition %d - package %v%v",
+				p.ID, testjson.RelativePackagePath(p.Packages[0]), extra)
 		}
 
 		m.Include[i] = p

--- a/cmd/tool/matrix/matrix.go
+++ b/cmd/tool/matrix/matrix.go
@@ -130,7 +130,7 @@ func readAndPruneTimingReports(opts options) ([]*os.File, error) {
 		return nil, err
 	}
 
-	var files []*os.File
+	files := make([]*os.File, 0, len(fileNames))
 	for _, fileName := range fileNames {
 		fh, err := os.Open(fileName)
 		if err != nil {

--- a/cmd/tool/matrix/matrix.go
+++ b/cmd/tool/matrix/matrix.go
@@ -31,7 +31,7 @@ func Run(name string, args []string) error {
 
 type options struct {
 	pruneFilesMaxAgeDays uint
-	buckets              uint
+	numPartitions        uint
 	timingFilesPattern   string
 	debug                bool
 }
@@ -45,8 +45,8 @@ func setupFlags(name string) (*pflag.FlagSet, *options) {
 	}
 	flags.UintVar(&opts.pruneFilesMaxAgeDays, "max-age-days", 0,
 		"timing files older than this value will be deleted")
-	flags.UintVar(&opts.buckets, "buckets", 4,
-		"number of parallel buckets to create in the test matrix")
+	flags.UintVar(&opts.numPartitions, "partitions", 0,
+		"number of parallel partitions to create in the test matrix")
 	flags.StringVar(&opts.timingFilesPattern, "timing-files", "",
 		"glob pattern to match files that contain test2json events, ex: ./logs/*.log")
 	flags.BoolVar(&opts.debug, "debug", false,
@@ -69,8 +69,8 @@ func run(opts options) error {
 	if opts.debug {
 		log.SetLevel(log.DebugLevel)
 	}
-	if opts.buckets < 2 {
-		return fmt.Errorf("--buckets must be atleast 2")
+	if opts.numPartitions < 2 {
+		return fmt.Errorf("--partitions must be atleast 2")
 	}
 	if opts.timingFilesPattern == "" {
 		return fmt.Errorf("--timing-files is required")
@@ -92,7 +92,7 @@ func run(opts options) error {
 		return err
 	}
 
-	buckets := bucketPackages(packagePercentile(pkgTiming), pkgs, opts.buckets)
+	buckets := bucketPackages(packagePercentile(pkgTiming), pkgs, opts.numPartitions)
 	return writeBuckets(buckets)
 }
 

--- a/cmd/tool/matrix/matrix_test.go
+++ b/cmd/tool/matrix/matrix_test.go
@@ -1,0 +1,112 @@
+package matrix
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestPackagePercentile(t *testing.T) {
+	ms := time.Millisecond
+	timing := map[string][]time.Duration{
+		"none":  {},
+		"one":   {time.Second},
+		"two":   {4 * ms, 2 * ms},
+		"three": {2 * ms, 3 * ms, 5 * ms},
+		"four":  {4 * ms, 3 * ms, ms, 2 * ms},
+		"five":  {6 * ms, 2 * ms, 3 * ms, 4 * ms, 9 * ms},
+		"nine":  {6 * ms, 2 * ms, 3 * ms, 4 * ms, 9 * ms, 1 * ms, 5 * ms, 7 * ms, 8 * ms},
+		"ten":   {6 * ms, 2 * ms, 3 * ms, 4 * ms, 9 * ms, 5 * ms, 7 * ms, 8 * ms, ms, ms},
+		"twenty": {
+			6 * ms, 2 * ms, 3 * ms, 4 * ms, 9 * ms, 5 * ms, 7 * ms, 8 * ms, ms, ms,
+			100, 200, 600, 700, 800, 900, 200, 300, 400, 500,
+		},
+	}
+
+	out := packagePercentile(timing)
+	expected := map[string]time.Duration{
+		"none":   0,
+		"one":    time.Second,
+		"two":    4 * ms,
+		"three":  5 * ms,
+		"four":   4 * ms,
+		"five":   9 * ms,
+		"nine":   8 * ms,
+		"ten":    8 * ms,
+		"twenty": 6 * ms,
+	}
+	assert.DeepEqual(t, out, expected)
+}
+
+func TestBucketPackages(t *testing.T) {
+	ms := time.Millisecond
+	timing := map[string]time.Duration{
+		"one":   190 * ms,
+		"two":   200 * ms,
+		"three": 3800 * ms,
+		"four":  4000 * ms,
+		"five":  50 * ms,
+		"six":   606 * ms,
+		"rm1":   time.Second,
+		"rm2":   time.Second,
+	}
+	packages := []string{"new1", "new2", "one", "two", "three", "four", "five", "six"}
+
+	type testCase struct {
+		n        uint
+		expected []bucket
+	}
+
+	run := func(t *testing.T, tc testCase) {
+		buckets := bucketPackages(timing, packages, tc.n)
+		assert.DeepEqual(t, buckets, tc.expected)
+	}
+
+	testCases := []testCase{
+		{
+			n: 2,
+			expected: []bucket{
+				0: {Total: 4440 * ms, Packages: []string{"four", "two", "one", "five"}},
+				1: {Total: 4406 * ms, Packages: []string{"three", "six", "new2", "new1"}},
+			},
+		},
+		{
+			n: 3,
+			expected: []bucket{
+				0: {Total: 4000 * ms, Packages: []string{"four"}},
+				1: {Total: 3800 * ms, Packages: []string{"three"}},
+				2: {Total: 1046 * ms, Packages: []string{"six", "two", "one", "five", "new1", "new2"}},
+			},
+		},
+		{
+			n: 4,
+			expected: []bucket{
+				0: {Total: 4000 * ms, Packages: []string{"four"}},
+				1: {Total: 3800 * ms, Packages: []string{"three"}},
+				2: {Total: 606 * ms, Packages: []string{"six"}},
+				3: {Total: 440 * ms, Packages: []string{"two", "one", "five", "new2", "new1"}},
+			},
+		},
+		{
+			n: 8,
+			expected: []bucket{
+				0: {Total: 4000 * ms, Packages: []string{"four"}},
+				1: {Total: 3800 * ms, Packages: []string{"three"}},
+				2: {Total: 606 * ms, Packages: []string{"six"}},
+				3: {Total: 200 * ms, Packages: []string{"two"}},
+				4: {Total: 190 * ms, Packages: []string{"one"}},
+				5: {Total: 50 * ms, Packages: []string{"five"}},
+				6: {Packages: []string{"new1"}},
+				7: {Packages: []string{"new2"}},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(strconv.FormatUint(uint64(tc.n), 10), func(t *testing.T) {
+			run(t, tc)
+		})
+	}
+}

--- a/cmd/tool/matrix/matrix_test.go
+++ b/cmd/tool/matrix/matrix_test.go
@@ -243,5 +243,5 @@ func TestRun(t *testing.T) {
 
 // expectedMatrix can be automatically updated by running tests with -update
 // nolint:lll
-var expectedMatrix = `{"include":[{"id":0,"estimatedRuntime":6000000000,"packages":["pkg2"],"description":"package pkg2 (6s)"},{"id":1,"estimatedRuntime":4000000000,"packages":["pkg1"],"description":"package pkg1 (4s)"},{"id":2,"estimatedRuntime":2000000000,"packages":["pkg0","other"],"description":"package pkg0 and 1 others (2s)"}]}
+var expectedMatrix = `{"include":[{"id":0,"estimatedRuntime":"6s","packages":["pkg2"],"description":"partition 0 - package pkg2"},{"id":1,"estimatedRuntime":"4s","packages":["pkg1"],"description":"partition 1 - package pkg1"},{"id":2,"estimatedRuntime":"2s","packages":["pkg0","other"],"description":"partition 2 - package pkg0 and 1 others"}]}
 `

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -11,6 +11,7 @@ type Level uint8
 const (
 	ErrorLevel Level = iota
 	WarnLevel
+	InfoLevel
 	DebugLevel
 )
 
@@ -37,6 +38,15 @@ func Warnf(format string, args ...interface{}) {
 // Debugf prints the message to stderr, with no prefix.
 func Debugf(format string, args ...interface{}) {
 	if level < DebugLevel {
+		return
+	}
+	fmt.Fprintf(out, format, args...)
+	fmt.Fprint(out, "\n")
+}
+
+// Infof prints the message to stderr, with no prefix.
+func Infof(format string, args ...interface{}) {
+	if level < InfoLevel {
 		return
 	}
 	fmt.Fprintf(out, format, args...)

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"gotest.tools/gotestsum/cmd"
+	"gotest.tools/gotestsum/cmd/tool/matrix"
 	"gotest.tools/gotestsum/cmd/tool/slowest"
 	"gotest.tools/gotestsum/internal/log"
 )
@@ -55,6 +56,7 @@ func toolRun(name string, args []string) error {
 
 Commands:
     %[1]s slowest      find or skip the slowest tests
+    %[1]s ci-matrix    use previous test runtime to place packages into optimal buckets
 
 Use '%[1]s COMMAND --help' for command specific help.
 `, name)
@@ -67,6 +69,8 @@ Use '%[1]s COMMAND --help' for command specific help.
 		return nil
 	case "slowest":
 		return slowest.Run(name+" "+next, rest)
+	case "ci-matrix":
+		return matrix.Run(name+" "+next, rest)
 	default:
 		fmt.Fprintln(os.Stderr, usage(name))
 		return fmt.Errorf("invalid command: %v %v", name, next)


### PR DESCRIPTION
This PR adds a new subcommand `gotestsum tool ci-matrix` for use with github actions.  The subcommand:
* reads `test2json` files saved in a github actions cache from previous test runs
* uses the `test2json` data to calculate the 85th percentile runtime of each package
* uses the package runtime to bucket all the packages into `n` buckets

A github actions workflow can then use those buckets in a [matrix](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs), so that packages are split between the buckets based on their runtime. This should result in optimal splitting of packages to minimize overall CI runtime.

Using the subcommand requires integration with github actions, so I'll need to document exact how to wire it all together.  Once it's working well, maybe it would make sense to publish an action to handle parts of it.