### PR TITLE
Add project name to junit.xml output

### DIFF
--- a/cmd/handler.go
+++ b/cmd/handler.go
@@ -93,6 +93,7 @@ func writeJUnitFile(opts *options, execution *testjson.Execution) error {
 	}()
 
 	return junitxml.Write(junitFile, execution, junitxml.Config{
+		ProjectName:             opts.junitProjectName,
 		FormatTestSuiteName:     opts.junitTestSuiteNameFormat.Value(),
 		FormatTestCaseClassname: opts.junitTestCaseClassnameFormat.Value(),
 	})

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -88,6 +88,9 @@ func setupFlags(name string) (*pflag.FlagSet, *options) {
 		"format the testsuite name field as: "+junitFieldFormatValues)
 	flags.Var(opts.junitTestCaseClassnameFormat, "junitfile-testcase-classname",
 		"format the testcase classname field as: "+junitFieldFormatValues)
+	flags.StringVar(&opts.junitProjectName, "junitfile-project-name",
+		lookEnvWithDefault("GOTESTSUM_JUNITFILE_PROJECT_NAME", ""),
+		"name of the project used in the junit.xml file")
 
 	flags.IntVar(&opts.rerunFailsMaxAttempts, "rerun-fails", 0,
 		"rerun failed tests until they all pass, or attempts exceeds maximum. Defaults to max 2 reruns when enabled.")
@@ -152,6 +155,7 @@ type options struct {
 	hideSummary                  *hideSummaryValue
 	junitTestSuiteNameFormat     *junitFieldFormatValue
 	junitTestCaseClassnameFormat *junitFieldFormatValue
+	junitProjectName             string
 	rerunFailsMaxAttempts        int
 	rerunFailsMaxInitialFailures int
 	rerunFailsReportFile         string

--- a/cmd/testdata/gotestsum-help-text
+++ b/cmd/testdata/gotestsum-help-text
@@ -8,6 +8,7 @@ Flags:
       --hide-summary summary                        hide sections of the summary: skipped,failed,errors,output (default none)
       --jsonfile string                             write all TestEvents to file
       --junitfile string                            write a JUnit XML file
+      --junitfile-project-name string               name of the project used in the junit.xml file
       --junitfile-testcase-classname field-format   format the testcase classname field as: full, relative, short (default full)
       --junitfile-testsuite-name field-format       format the testsuite name field as: full, relative, short (default full)
       --max-fails int                               end the test run after this number of failures

--- a/internal/junitxml/report_test.go
+++ b/internal/junitxml/report_test.go
@@ -20,7 +20,11 @@ func TestWrite(t *testing.T) {
 	exec := createExecution(t)
 
 	env.Patch(t, "GOVERSION", "go7.7.7")
-	err := Write(out, exec, Config{customTimestamp: new(time.Time).Format(time.RFC3339)})
+	err := Write(out, exec, Config{
+		ProjectName:     "test",
+		customTimestamp: new(time.Time).Format(time.RFC3339),
+		customElapsed:   "2.1",
+	})
 	assert.NilError(t, err)
 	golden.Assert(t, out.String(), "junitxml-report.golden")
 }

--- a/internal/junitxml/testdata/junitxml-report.golden
+++ b/internal/junitxml/testdata/junitxml-report.golden
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites>
+<testsuites name="test" tests="59" failures="13" errors="1" time="2.1">
 	<testsuite tests="0" failures="0" time="0.001000" name="gotest.tools/gotestsum/testjson/internal/badmain" timestamp="0001-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="go7.7.7"></property>


### PR DESCRIPTION
Add attributes `name`, `timestamp`, `tests`, `failures`, `errors`, `skipepd`, `time`, `hostname` to the `testsuites` xml node, according to the schema: https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd.