### PR TITLE
Test against go1.19, remove go1.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,13 +7,6 @@ workflows:
   ci:
     jobs:
       - go/test:
-          name: test-go-1.15
-          gotestsum-format: testname
-          executor:
-            name: go/golang
-            tag: 1.15-alpine
-
-      - go/test:
           name: test-go-1.16
           gotestsum-format: testname
           executor:
@@ -35,6 +28,13 @@ workflows:
             tag: 1.18-alpine
 
       - go/test:
+          name: test-go-1.19
+          gotestsum-format: testname
+          executor:
+            name: go/golang
+            tag: 1.19-alpine
+
+      - go/test:
           name: test-windows
           executor: windows
           pre-steps:
@@ -47,7 +47,7 @@ workflows:
             - run: go version
 
       - go/lint:
-          golangci-lint-version: 1.42.0
+          golangci-lint-version: 1.48.0
 
       - build
       - run
@@ -94,7 +94,7 @@ jobs:
         default: false
     executor:
       name: go/golang
-      tag: 1.18-alpine
+      tag: 1.19-alpine
     steps:
       - go/install: {package: git}
       - go/install-ssh

--- a/internal/dotwriter/writer.go
+++ b/internal/dotwriter/writer.go
@@ -1,4 +1,5 @@
-/*Package dotwriter implements a buffered Writer for updating progress on the
+/*
+Package dotwriter implements a buffered Writer for updating progress on the
 terminal.
 */
 package dotwriter

--- a/testjson/doc.go
+++ b/testjson/doc.go
@@ -1,22 +1,22 @@
-/*Package testjson scans test2json output and builds up a summary of the events.
+/*
+Package testjson scans test2json output and builds up a summary of the events.
 Events are passed to a formatter for output.
 
-Example
+# Example
 
 This example reads the test2json output from os.Stdin. It sends every
 event to the handler, builds an Execution from the output, then it
 prints the number of tests run.
 
-    exec, err := testjson.ScanTestOutput(testjson.ScanConfig{
-        // Stdout is a reader that provides the test2json output stream.
-        Stdout: os.Stdin,
-        // Handler receives TestEvents and error lines.
-        Handler: eventHandler,
-    })
-    if err != nil {
-        return fmt.Errorf("failed to scan testjson: %w", err)
-    }
-    fmt.Println("Ran %d tests", exec.Total())
-
+	exec, err := testjson.ScanTestOutput(testjson.ScanConfig{
+	    // Stdout is a reader that provides the test2json output stream.
+	    Stdout: os.Stdin,
+	    // Handler receives TestEvents and error lines.
+	    Handler: eventHandler,
+	})
+	if err != nil {
+	    return fmt.Errorf("failed to scan testjson: %w", err)
+	}
+	fmt.Println("Ran %d tests", exec.Total())
 */
 package testjson // import "gotest.tools/gotestsum/testjson"

--- a/testjson/execution.go
+++ b/testjson/execution.go
@@ -158,6 +158,7 @@ func (p *Package) Output(id int) string {
 // As a workaround for test output being attributed to the wrong subtest, if:
 //   - the TestCase is a root TestCase (not a subtest), and
 //   - the TestCase has no subtest failures;
+//
 // then all output for every subtest under the root test is returned.
 // See https://github.com/golang/go/issues/29755.
 func (p *Package) OutputLines(tc TestCase) []string {


### PR DESCRIPTION
And update `gofmt` for new go.19 format.

Closes #183

Because go1.19 now includes these fixes in the stdlib: https://tip.golang.org/doc/go1.19#os-exec-path