### PR TITLE
Adding in support for s390x and ppc64le

### DIFF
--- a/.project/goreleaser.yml
+++ b/.project/goreleaser.yml
@@ -16,8 +16,19 @@ builds:
       - amd64
       - arm64
       - arm
+      - s390x
+      - ppc64le
     env: [CGO_ENABLED=0]
-    ldflags: ["-s -w -X gotest.tools/gotestsum/cmd.version={{.Version}}"]
+    ldflags: ["-s -w -X gotest.tools/gotestsum/cmd.version={{.Version}}"]  
+    ignore:
+      - goos: darwin
+        goarch: s390x
+      - goos: darwin
+        goarch: ppc64le
+      - goos: windows
+        goarch: s390x
+      - goos: windows
+        goarch: ppc64le
 
 checksum:
   name_template: '{{ .ProjectName }}-{{ .Version }}-checksums.txt'


### PR DESCRIPTION
Added in support for `s390x` and `ppc64le` on Linux. 

In my testing I was able to see a successful build on CircleCI linked [here](https://app.circleci.com/pipelines/github/james-crowley/gotestsum/2/workflows/a72c6864-82b7-43d8-b920-2c2489a6ea75/jobs/11). This build allowed me to pull down the `s390x` artifact from CircleCI to validate a successful build.

```
linux1@circleci-runner-s390x:~$ wget https://output.circle-artifacts.com/output/job/a0e9cf72-e153-4b73-a04a-9eb6ef1f5499/artifacts/0/dist/gotestsum_linux_s390x/gotestsum && chmod +x gotestsum
linux1@circleci-runner-s390x:~$ ./gotestsum --version
gotestsum version 0.0.0-SNAPSHOT-85a7f9e
linux1@circleci-runner-s390x:~$ arch
s390x
```

Closes #268 

@dnephin Let me know if you need anything else for this PR to be merged. Happy to help! 