### PR TITLE
Add a flag for running the entire root test case when any of its subtests fail

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -101,9 +101,8 @@ func setupFlags(name string) (*pflag.FlagSet, *options) {
 		"space separated list of package to test")
 	flags.StringVar(&opts.rerunFailsReportFile, "rerun-fails-report", "",
 		"write a report to the file, of the tests that were rerun")
-	flags.BoolVar(&opts.rerunFailsOnlyRootCases, "rerun-fails-only-root-testcases", false,
-		"rerun only root testcaes, instead of only subtests")
-	flags.Lookup("rerun-fails-only-root-testcases").Hidden = true
+	flags.BoolVar(&opts.rerunFailsRunRootCases, "rerun-fails-run-root-test", false,
+		"rerun the entire root testcase when any of its subtests fail, instead of only the failed subtest")
 
 	flags.BoolVar(&opts.debug, "debug", false, "enabled debug logging")
 	flags.BoolVar(&opts.version, "version", false, "show version and exit")
@@ -159,7 +158,7 @@ type options struct {
 	rerunFailsMaxAttempts        int
 	rerunFailsMaxInitialFailures int
 	rerunFailsReportFile         string
-	rerunFailsOnlyRootCases      bool
+	rerunFailsRunRootCases       bool
 	packages                     []string
 	watch                        bool
 	maxFails                     int

--- a/cmd/rerunfails.go
+++ b/cmd/rerunfails.go
@@ -35,9 +35,15 @@ func newRerunOptsFromTestCase(tc testjson.TestCase) rerunOpts {
 type testCaseFilter func([]testjson.TestCase) []testjson.TestCase
 
 func rerunFailsFilter(o *options) testCaseFilter {
-	if o.rerunFailsOnlyRootCases {
+	if o.rerunFailsRunRootCases {
 		return func(tcs []testjson.TestCase) []testjson.TestCase {
-			return tcs
+			var result []testjson.TestCase
+			for _, tc := range tcs {
+				if !tc.Test.IsSubTest() {
+					result = append(result, tc)
+				}
+			}
+			return result
 		}
 	}
 	return testjson.FilterFailedUnique

--- a/cmd/testdata/gotestsum-help-text
+++ b/cmd/testdata/gotestsum-help-text
@@ -19,6 +19,7 @@ Flags:
       --rerun-fails int[=2]                         rerun failed tests until they all pass, or attempts exceeds maximum. Defaults to max 2 reruns when enabled.
       --rerun-fails-max-failures int                do not rerun any tests if the initial run has more than this number of failures (default 10)
       --rerun-fails-report string                   write a report to the file, of the tests that were rerun
+      --rerun-fails-run-root-test                   rerun the entire root testcase when any of its subtests fail, instead of only the failed subtest
       --version                                     show version and exit
       --watch                                       watch go files, and run tests when a file is modified
 

--- a/internal/text/testing.go
+++ b/internal/text/testing.go
@@ -4,15 +4,19 @@ import (
 	"bufio"
 	"io"
 	"strings"
-	"testing"
 
 	"gotest.tools/v3/assert"
 )
 
+type TestingT interface {
+	Helper()
+	assert.TestingT
+}
+
 // ProcessLines from the Reader by passing each one to ops. The output of each
 // op is passed to the next. Returns the string created by joining all the
 // processed lines.
-func ProcessLines(t *testing.T, r io.Reader, ops ...func(string) string) string {
+func ProcessLines(t TestingT, r io.Reader, ops ...func(string) string) string {
 	t.Helper()
 	out := new(strings.Builder)
 	scan := bufio.NewScanner(r)


### PR DESCRIPTION
Related to #274

There was a hidden flag that did something similar, but I never fixed that flag to work correctly after changing `--rerun-fails` to run individual tests.  This PR fixes the logic to run only root test cases with failures (instead of running both root and subtests), renames the flag to `--rerun-fails-run-root-test`, and unhides it so that it shows up in help text.