### PR TITLE
Error if `-failfast` is used with `--rerun-fails`

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -174,8 +174,12 @@ type options struct {
 func (o options) Validate() error {
 	if o.rerunFailsMaxAttempts > 0 && len(o.args) > 0 && !o.rawCommand && len(o.packages) == 0 {
 		return fmt.Errorf(
-			"when go test args are used with --rerun-fails-max-attempts " +
+			"when go test args are used with --rerun-fails " +
 				"the list of packages to test must be specified by the --packages flag")
+	}
+	if o.rerunFailsMaxAttempts > 0 && boolArgIndex("failfast", o.args) > -1 {
+		return fmt.Errorf("-failfast can not be used with --rerun-fails " +
+			"because not all test cases will run")
 	}
 	return nil
 }

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -70,6 +70,11 @@ func TestOptions_Validate_FromFlags(t *testing.T) {
 			name: "rerun flag, no go-test args, with packages flag",
 			args: []string{"--rerun-fails", "--packages", "./..."},
 		},
+		{
+			name:     "rerun-fails with failfast",
+			args:     []string{"--rerun-fails", "--packages=./...", "--", "-failfast"},
+			expected: "-failfast can not be used with --rerun-fails",
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
`-failfast` stops the initial run of tests before all tests are run, so gotestsum never sees the full list of tests. When `gotestsum` goes to re-run tests, it uses the list of failed tests from the initial test run. Since only some of the tests ran, it never has the change to re-run all the tests that were skipped by `-failfast`.

`-failfast` has other problems (golang/go#30522, golang/go#33038).  If we wanted to support this combination of flags it is possible that `gotestsum` could get the list of tests from `go test --list`, however that introduces other problems. `go test --list` can be pretty slow, which adds more time to the overall test run. It also only lists top-level test cases, so there would be no way to re-run only failed subtests. That effectively makes the behaviour introduced in #275 the default and there'd be no way to support the current behaviour of re-running only the subtests that failed. I'd like to avoid that approach, so I think the best option for now is to refuse to run.  https://github.com/gotestyourself/gotestsum/issues/278#issuecomment-1238681323 has a recommendation for re-running all tests along with `-failfast`.


Related to #278