### PR TITLE
Hide empty packages in compact formats

### DIFF
--- a/cmd/handler.go
+++ b/cmd/handler.go
@@ -57,7 +57,7 @@ func (h *eventHandler) Close() error {
 var _ testjson.EventHandler = &eventHandler{}
 
 func newEventHandler(opts *options) (*eventHandler, error) {
-	formatter := testjson.NewEventFormatter(opts.stdout, opts.format)
+	formatter := testjson.NewEventFormatter(opts.stdout, opts.format, opts.formatOptions)
 	if formatter == nil {
 		return nil, fmt.Errorf("unknown format %s", opts.format)
 	}

--- a/cmd/handler_test.go
+++ b/cmd/handler_test.go
@@ -59,7 +59,7 @@ func (bufferCloser) Close() error { return nil }
 func TestEventHandler_Event_WithMissingActionFail(t *testing.T) {
 	buf := new(bufferCloser)
 	errBuf := new(bytes.Buffer)
-	format := testjson.NewEventFormatter(errBuf, "testname")
+	format := testjson.NewEventFormatter(errBuf, "testname", testjson.FormatOptions{})
 
 	source := golden.Get(t, "../../testjson/testdata/input/go-test-json-missing-test-fail.out")
 	cfg := testjson.ScanConfig{
@@ -76,7 +76,7 @@ func TestEventHandler_Event_WithMissingActionFail(t *testing.T) {
 }
 
 func TestEventHandler_Event_MaxFails(t *testing.T) {
-	format := testjson.NewEventFormatter(ioutil.Discard, "testname")
+	format := testjson.NewEventFormatter(ioutil.Discard, "testname", testjson.FormatOptions{})
 
 	source := golden.Get(t, "../../testjson/testdata/input/go-test-json.out")
 	cfg := testjson.ScanConfig{

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -59,6 +59,8 @@ func setupFlags(name string) (*pflag.FlagSet, *options) {
 	flags.StringVarP(&opts.format, "format", "f",
 		lookEnvWithDefault("GOTESTSUM_FORMAT", "short"),
 		"print format of test input")
+	flags.BoolVar(&opts.formatOptions.HideEmptyPackages, "format-hide-empty-pkg",
+		false, "do not print empty packages in compact formats")
 	flags.BoolVar(&opts.rawCommand, "raw-command", false,
 		"don't prepend 'go test -json' to the 'go test' command")
 	flags.BoolVar(&opts.ignoreNonJSONOutputLines, "ignore-non-json-output-lines", false,
@@ -146,6 +148,7 @@ func lookEnvWithDefault(key, defValue string) string {
 type options struct {
 	args                         []string
 	format                       string
+	formatOptions                testjson.FormatOptions
 	debug                        bool
 	rawCommand                   bool
 	ignoreNonJSONOutputLines     bool

--- a/cmd/testdata/gotestsum-help-text
+++ b/cmd/testdata/gotestsum-help-text
@@ -7,6 +7,7 @@ See https://pkg.go.dev/gotest.tools/gotestsum#section-readme for detailed docume
 Flags:
       --debug                                       enabled debug logging
   -f, --format string                               print format of test input (default "short")
+      --format-hide-empty-pkg                       do not print empty packages in compact formats
       --hide-summary summary                        hide sections of the summary: skipped,failed,errors,output (default none)
       --jsonfile string                             write all TestEvents to file
       --junitfile string                            write a JUnit XML file

--- a/testjson/dotformat_test.go
+++ b/testjson/dotformat_test.go
@@ -129,7 +129,7 @@ func TestFmtDotElapsed_RuneCountProperty(t *testing.T) {
 
 func TestNewDotFormatter(t *testing.T) {
 	buf := new(bytes.Buffer)
-	ef := newDotFormatter(buf)
+	ef := newDotFormatter(buf, FormatOptions{})
 
 	d, ok := ef.(*dotFormatter)
 	skip.If(t, !ok, "no terminal width")

--- a/testjson/format.go
+++ b/testjson/format.go
@@ -211,8 +211,12 @@ type EventFormatter interface {
 	Format(event TestEvent, output *Execution) error
 }
 
+type FormatOptions struct {
+	HideEmptyPackages bool
+}
+
 // NewEventFormatter returns a formatter for printing events.
-func NewEventFormatter(out io.Writer, format string) EventFormatter {
+func NewEventFormatter(out io.Writer, format string, formatOpts FormatOptions) EventFormatter {
 	switch format {
 	case "debug":
 		return &formatAdapter{out, debugFormat}
@@ -223,7 +227,7 @@ func NewEventFormatter(out io.Writer, format string) EventFormatter {
 	case "dots", "dots-v1":
 		return &formatAdapter{out, dotsFormatV1}
 	case "dots-v2":
-		return newDotFormatter(out)
+		return newDotFormatter(out, formatOpts)
 	case "testname", "short-verbose":
 		return &formatAdapter{out, testNameFormat}
 	case "pkgname", "short":

--- a/testjson/format.go
+++ b/testjson/format.go
@@ -128,14 +128,16 @@ func all(cond ...bool) bool {
 	return true
 }
 
-func pkgNameFormat(event TestEvent, exec *Execution) string {
-	if !event.PackageEvent() {
-		return ""
+func pkgNameFormat(opts FormatOptions) func(event TestEvent, exec *Execution) string {
+	return func(event TestEvent, exec *Execution) string {
+		if !event.PackageEvent() {
+			return ""
+		}
+		return shortFormatPackageEvent(opts, event, exec)
 	}
-	return shortFormatPackageEvent(event, exec)
 }
 
-func shortFormatPackageEvent(event TestEvent, exec *Execution) string {
+func shortFormatPackageEvent(opts FormatOptions, event TestEvent, exec *Execution) string {
 	pkg := exec.Package(event.Package)
 
 	fmtEvent := func(action string) string {
@@ -144,9 +146,15 @@ func shortFormatPackageEvent(event TestEvent, exec *Execution) string {
 	withColor := colorEvent(event)
 	switch event.Action {
 	case ActionSkip:
+		if opts.HideEmptyPackages {
+			return ""
+		}
 		return fmtEvent(withColor("∅"))
 	case ActionPass:
 		if pkg.Total == 0 {
+			if opts.HideEmptyPackages {
+				return ""
+			}
 			return fmtEvent(withColor("∅"))
 		}
 		return fmtEvent(withColor("✓"))
@@ -181,16 +189,18 @@ func packageLine(event TestEvent, exec *Execution) string {
 	return buf.String()
 }
 
-func pkgNameWithFailuresFormat(event TestEvent, exec *Execution) string {
-	if !event.PackageEvent() {
-		if event.Action == ActionFail {
-			pkg := exec.Package(event.Package)
-			tc := pkg.LastFailedByName(event.Test)
-			return pkg.Output(tc.ID)
+func pkgNameWithFailuresFormat(opts FormatOptions) func(event TestEvent, exec *Execution) string {
+	return func(event TestEvent, exec *Execution) string {
+		if !event.PackageEvent() {
+			if event.Action == ActionFail {
+				pkg := exec.Package(event.Package)
+				tc := pkg.LastFailedByName(event.Test)
+				return pkg.Output(tc.ID)
+			}
+			return ""
 		}
-		return ""
+		return shortFormatPackageEvent(opts, event, exec)
 	}
-	return shortFormatPackageEvent(event, exec)
 }
 
 func colorEvent(event TestEvent) func(format string, a ...interface{}) string {
@@ -231,9 +241,9 @@ func NewEventFormatter(out io.Writer, format string, formatOpts FormatOptions) E
 	case "testname", "short-verbose":
 		return &formatAdapter{out, testNameFormat}
 	case "pkgname", "short":
-		return &formatAdapter{out, pkgNameFormat}
+		return &formatAdapter{out, pkgNameFormat(formatOpts)}
 	case "pkgname-and-test-fails", "short-with-failures":
-		return &formatAdapter{out, pkgNameWithFailuresFormat}
+		return &formatAdapter{out, pkgNameWithFailuresFormat(formatOpts)}
 	default:
 		return nil
 	}

--- a/testjson/format_test.go
+++ b/testjson/format_test.go
@@ -111,8 +111,13 @@ func TestFormats_DefaultGoTestJson(t *testing.T) {
 		},
 		{
 			name:        "pkgname",
-			format:      pkgNameFormat,
+			format:      pkgNameFormat(FormatOptions{}),
 			expectedOut: "format/pkgname.out",
+		},
+		{
+			name:        "pkgname",
+			format:      pkgNameFormat(FormatOptions{HideEmptyPackages: true}),
+			expectedOut: "format/pkgname-hide-empty.out",
 		},
 		{
 			name:        "standard-verbose",
@@ -163,7 +168,7 @@ func TestFormats_Coverage(t *testing.T) {
 		},
 		{
 			name:        "pkgname",
-			format:      pkgNameFormat,
+			format:      pkgNameFormat(FormatOptions{}),
 			expectedOut: "format/pkgname-coverage.out",
 		},
 		{
@@ -214,7 +219,7 @@ func TestFormats_Shuffle(t *testing.T) {
 		},
 		{
 			name:        "pkgname",
-			format:      pkgNameFormat,
+			format:      pkgNameFormat(FormatOptions{}),
 			expectedOut: "format/pkgname-shuffle.out",
 		},
 		{

--- a/testjson/testdata/format/pkgname-hide-empty.out
+++ b/testjson/testdata/format/pkgname-hide-empty.out
@@ -1,0 +1,4 @@
+✖  testjson/internal/badmain (1ms)
+✓  testjson/internal/good (cached)
+✖  testjson/internal/parallelfails (20ms)
+✖  testjson/internal/withfails (20ms)


### PR DESCRIPTION
Related to #228
Closes #282

Add a new `--format-hide-empty-pkg` flag to hide empty package in compact formats. The `testname` format should be verbose enough that a few extra `EMPTY` lines for packages is not a big deal, and the `standard` formats should emulate the `go test` output as close as possible, so we don't want it to apply to those. 

I tested both formats manually, and added golden tests for `pkgname`. 