### PR TITLE
feat(freebsd): generate arm/amd64 binaries for FreeBSD

### DIFF
--- a/.project/goreleaser.yml
+++ b/.project/goreleaser.yml
@@ -10,6 +10,7 @@ builds:
   - binary: gotestsum
     goos:
       - darwin
+      - freebsd
       - windows
       - linux
     goarch:
@@ -25,6 +26,12 @@ builds:
         goarch: s390x
       - goos: darwin
         goarch: ppc64le
+      - goos: freebsd
+        goarch: s390x
+      - goos: freebsd
+        goarch: ppc64le
+      - goos: freebsd
+        goarch: arm
       - goos: windows
         goarch: s390x
       - goos: windows


### PR DESCRIPTION
fixes https://github.com/gotestyourself/gotestsum/issues/289

re: exclusion of `arm`

https://www.freebsd.org/platforms/arm/

> 32-bit ARMv6 and ARMv7 is officially a [Tier 2](https://docs.freebsd.org/en/articles/committers-guide/#archs) architecture, as the [FreeBSD](https://www.freebsd.org/) project does not provide official releases or pre-built packages for this platform due to it primarily targeting the embedded arena.
> 
> FreeBSD/arm64 supports 64-bit ARMv8 processors and is a [Tier 1](https://docs.freebsd.org/en/articles/committers-guide/#archs) architecture as of 13.0. 64-bit ARM platforms follow a set of standard conventions, and a single FreeBSD build will work on hardware from multiple vendors. As a result, FreeBSD provides official releases for FreeBSD/arm64 and packages are available.