### PR TITLE
Add option to use high-visibility icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ The `--format` flag or `GOTESTSUM_FORMAT` environment variable set the format th
 is used to print the test names, and possibly test output, as the tests run. Most
 outputs use color to highlight pass, fail, or skip.
 
+The `--format-hivis` flag changes the icons used by `pkgname` formats to higher
+visiblity unicode characters.
+
 Commonly used formats (see `--help` for a full list):
 
  * `dots` - print a character for each test.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -61,6 +61,8 @@ func setupFlags(name string) (*pflag.FlagSet, *options) {
 		"print format of test input")
 	flags.BoolVar(&opts.formatOptions.HideEmptyPackages, "format-hide-empty-pkg",
 		false, "do not print empty packages in compact formats")
+	flags.BoolVar(&opts.formatOptions.UseHiVisibilityIcons, "format-hivis",
+		false, "use high visibility characters in some formats")
 	flags.BoolVar(&opts.rawCommand, "raw-command", false,
 		"don't prepend 'go test -json' to the 'go test' command")
 	flags.BoolVar(&opts.ignoreNonJSONOutputLines, "ignore-non-json-output-lines", false,
@@ -127,15 +129,13 @@ Flags:
 	flags.PrintDefaults()
 	fmt.Fprintf(out, `
 Formats:
-    dots                           print a character for each test
-    dots-v2                        experimental dots format, one package per line
-    pkgname                        print a line for each package
-    pkgname-hivis                  print a line for each package, use hi-visability icons
-    pkgname-and-test-fails         print a line for each package and failed test output
-    pkgname-and-test-fails-hivis   print a line for each package and failed test output, use hi-visability icons
-    testname                       print a line for each test and package
-    standard-quiet                 standard go test format
-    standard-verbose               standard go test -v format
+    dots                     print a character for each test
+    dots-v2                  experimental dots format, one package per line
+    pkgname                  print a line for each package
+    pkgname-and-test-fails   print a line for each package and failed test output
+    testname                 print a line for each test and package
+    standard-quiet           standard go test format
+    standard-verbose         standard go test -v format
 
 Commands:
     %[1]s tool slowest   find or skip the slowest tests

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -127,13 +127,15 @@ Flags:
 	flags.PrintDefaults()
 	fmt.Fprintf(out, `
 Formats:
-    dots                     print a character for each test
-    dots-v2                  experimental dots format, one package per line
-    pkgname                  print a line for each package
-    pkgname-and-test-fails   print a line for each package and failed test output
-    testname                 print a line for each test and package
-    standard-quiet           standard go test format
-    standard-verbose         standard go test -v format
+    dots                           print a character for each test
+    dots-v2                        experimental dots format, one package per line
+    pkgname                        print a line for each package
+    pkgname-hivis                  print a line for each package, use hi-visability icons
+    pkgname-and-test-fails         print a line for each package and failed test output
+    pkgname-and-test-fails-hivis   print a line for each package and failed test output, use hi-visability icons
+    testname                       print a line for each test and package
+    standard-quiet                 standard go test format
+    standard-verbose               standard go test -v format
 
 Commands:
     %[1]s tool slowest   find or skip the slowest tests

--- a/cmd/testdata/gotestsum-help-text
+++ b/cmd/testdata/gotestsum-help-text
@@ -8,6 +8,7 @@ Flags:
       --debug                                       enabled debug logging
   -f, --format string                               print format of test input (default "short")
       --format-hide-empty-pkg                       do not print empty packages in compact formats
+      --format-hivis                                use high visibility characters in some formats
       --hide-summary summary                        hide sections of the summary: skipped,failed,errors,output (default none)
       --jsonfile string                             write all TestEvents to file
       --junitfile string                            write a JUnit XML file
@@ -28,15 +29,13 @@ Flags:
       --watch                                       watch go files, and run tests when a file is modified
 
 Formats:
-    dots                           print a character for each test
-    dots-v2                        experimental dots format, one package per line
-    pkgname                        print a line for each package
-    pkgname-hivis                  print a line for each package, use hi-visability icons
-    pkgname-and-test-fails         print a line for each package and failed test output
-    pkgname-and-test-fails-hivis   print a line for each package and failed test output, use hi-visability icons
-    testname                       print a line for each test and package
-    standard-quiet                 standard go test format
-    standard-verbose               standard go test -v format
+    dots                     print a character for each test
+    dots-v2                  experimental dots format, one package per line
+    pkgname                  print a line for each package
+    pkgname-and-test-fails   print a line for each package and failed test output
+    testname                 print a line for each test and package
+    standard-quiet           standard go test format
+    standard-verbose         standard go test -v format
 
 Commands:
     gotestsum tool slowest   find or skip the slowest tests

--- a/cmd/testdata/gotestsum-help-text
+++ b/cmd/testdata/gotestsum-help-text
@@ -28,13 +28,15 @@ Flags:
       --watch                                       watch go files, and run tests when a file is modified
 
 Formats:
-    dots                     print a character for each test
-    dots-v2                  experimental dots format, one package per line
-    pkgname                  print a line for each package
-    pkgname-and-test-fails   print a line for each package and failed test output
-    testname                 print a line for each test and package
-    standard-quiet           standard go test format
-    standard-verbose         standard go test -v format
+    dots                           print a character for each test
+    dots-v2                        experimental dots format, one package per line
+    pkgname                        print a line for each package
+    pkgname-hivis                  print a line for each package, use hi-visability icons
+    pkgname-and-test-fails         print a line for each package and failed test output
+    pkgname-and-test-fails-hivis   print a line for each package and failed test output, use hi-visability icons
+    testname                       print a line for each test and package
+    standard-quiet                 standard go test format
+    standard-verbose               standard go test -v format
 
 Commands:
     gotestsum tool slowest   find or skip the slowest tests

--- a/testjson/format.go
+++ b/testjson/format.go
@@ -8,16 +8,6 @@ import (
 	"github.com/fatih/color"
 )
 
-const (
-	hivisSuffiz         = "-hivis"
-	defaultEmptyEmoji   = "∅"
-	defaultSuccessEmoji = "✓"
-	defaultFailEmoji    = "✖"
-	hivisEmptyEmpji     = "🔳"
-	hivisSuccessEmoji   = "✅"
-	hivisFailEmoji      = "❌"
-)
-
 func debugFormat(event TestEvent, _ *Execution) string {
 	return fmt.Sprintf("%s %s %s (%.3f) [%d] %s\n",
 		event.Package,
@@ -149,16 +139,16 @@ func pkgNameFormat(opts FormatOptions) func(event TestEvent, exec *Execution) st
 
 func shortFormatPackageEvent(opts FormatOptions, event TestEvent, exec *Execution) string {
 	pkg := exec.Package(event.Package)
-	var emptyEmoji, successEmoji, failEmoji string
 
-	if opts.UseHivisEmojis {
-		emptyEmoji = hivisEmptyEmpji
-		successEmoji = hivisSuccessEmoji
-		failEmoji = hivisFailEmoji
+	var iconSkipped, iconSuccess, iconFailure string
+	if opts.UseHiVisibilityIcons {
+		iconSkipped = "➖"
+		iconSuccess = "✅"
+		iconFailure = "❌"
 	} else {
-		emptyEmoji = defaultEmptyEmoji
-		successEmoji = defaultSuccessEmoji
-		failEmoji = defaultFailEmoji
+		iconSkipped = "∅"
+		iconSuccess = "✓"
+		iconFailure = "✖"
 	}
 
 	fmtEvent := func(action string) string {
@@ -170,17 +160,17 @@ func shortFormatPackageEvent(opts FormatOptions, event TestEvent, exec *Executio
 		if opts.HideEmptyPackages {
 			return ""
 		}
-		return fmtEvent(withColor(emptyEmoji))
+		return fmtEvent(withColor(iconSkipped))
 	case ActionPass:
 		if pkg.Total == 0 {
 			if opts.HideEmptyPackages {
 				return ""
 			}
-			return fmtEvent(withColor(emptyEmoji))
+			return fmtEvent(withColor(iconSkipped))
 		}
-		return fmtEvent(withColor(successEmoji))
+		return fmtEvent(withColor(iconSuccess))
 	case ActionFail:
-		return fmtEvent(withColor(failEmoji))
+		return fmtEvent(withColor(iconFailure))
 	}
 	return ""
 }
@@ -243,16 +233,12 @@ type EventFormatter interface {
 }
 
 type FormatOptions struct {
-	HideEmptyPackages bool
-	UseHivisEmojis    bool
+	HideEmptyPackages    bool
+	UseHiVisibilityIcons bool
 }
 
 // NewEventFormatter returns a formatter for printing events.
 func NewEventFormatter(out io.Writer, format string, formatOpts FormatOptions) EventFormatter {
-	if strings.HasSuffix(format, hivisSuffiz) {
-		formatOpts.UseHivisEmojis = true
-		format = strings.TrimSuffix(format, hivisSuffiz)
-	}
 	switch format {
 	case "debug":
 		return &formatAdapter{out, debugFormat}

--- a/testjson/format.go
+++ b/testjson/format.go
@@ -8,6 +8,16 @@ import (
 	"github.com/fatih/color"
 )
 
+const (
+	hivisSuffiz         = "-hivis"
+	defaultEmptyEmoji   = "∅"
+	defaultSuccessEmoji = "✓"
+	defaultFailEmoji    = "✖"
+	hivisEmptyEmpji     = "🔳"
+	hivisSuccessEmoji   = "✅"
+	hivisFailEmoji      = "❌"
+)
+
 func debugFormat(event TestEvent, _ *Execution) string {
 	return fmt.Sprintf("%s %s %s (%.3f) [%d] %s\n",
 		event.Package,
@@ -139,6 +149,17 @@ func pkgNameFormat(opts FormatOptions) func(event TestEvent, exec *Execution) st
 
 func shortFormatPackageEvent(opts FormatOptions, event TestEvent, exec *Execution) string {
 	pkg := exec.Package(event.Package)
+	var emptyEmoji, successEmoji, failEmoji string
+
+	if opts.UseHivisEmojis {
+		emptyEmoji = hivisEmptyEmpji
+		successEmoji = hivisSuccessEmoji
+		failEmoji = hivisFailEmoji
+	} else {
+		emptyEmoji = defaultEmptyEmoji
+		successEmoji = defaultSuccessEmoji
+		failEmoji = defaultFailEmoji
+	}
 
 	fmtEvent := func(action string) string {
 		return action + "  " + packageLine(event, exec)
@@ -149,17 +170,17 @@ func shortFormatPackageEvent(opts FormatOptions, event TestEvent, exec *Executio
 		if opts.HideEmptyPackages {
 			return ""
 		}
-		return fmtEvent(withColor("∅"))
+		return fmtEvent(withColor(emptyEmoji))
 	case ActionPass:
 		if pkg.Total == 0 {
 			if opts.HideEmptyPackages {
 				return ""
 			}
-			return fmtEvent(withColor("∅"))
+			return fmtEvent(withColor(emptyEmoji))
 		}
-		return fmtEvent(withColor("✓"))
+		return fmtEvent(withColor(successEmoji))
 	case ActionFail:
-		return fmtEvent(withColor("✖"))
+		return fmtEvent(withColor(failEmoji))
 	}
 	return ""
 }
@@ -223,10 +244,15 @@ type EventFormatter interface {
 
 type FormatOptions struct {
 	HideEmptyPackages bool
+	UseHivisEmojis    bool
 }
 
 // NewEventFormatter returns a formatter for printing events.
 func NewEventFormatter(out io.Writer, format string, formatOpts FormatOptions) EventFormatter {
+	if strings.HasSuffix(format, hivisSuffiz) {
+		formatOpts.UseHivisEmojis = true
+		format = strings.TrimSuffix(format, hivisSuffiz)
+	}
 	switch format {
 	case "debug":
 		return &formatAdapter{out, debugFormat}

--- a/testjson/format_test.go
+++ b/testjson/format_test.go
@@ -115,6 +115,11 @@ func TestFormats_DefaultGoTestJson(t *testing.T) {
 			expectedOut: "format/pkgname.out",
 		},
 		{
+			name:        "pkgname-hivis",
+			format:      pkgNameFormat(FormatOptions{UseHivisEmojis: true}),
+			expectedOut: "format/pkgname-hivis.out",
+		},
+		{
 			name:        "pkgname",
 			format:      pkgNameFormat(FormatOptions{HideEmptyPackages: true}),
 			expectedOut: "format/pkgname-hide-empty.out",

--- a/testjson/format_test.go
+++ b/testjson/format_test.go
@@ -116,7 +116,7 @@ func TestFormats_DefaultGoTestJson(t *testing.T) {
 		},
 		{
 			name:        "pkgname-hivis",
-			format:      pkgNameFormat(FormatOptions{UseHivisEmojis: true}),
+			format:      pkgNameFormat(FormatOptions{UseHiVisibilityIcons: true}),
 			expectedOut: "format/pkgname-hivis.out",
 		},
 		{

--- a/testjson/testdata/format/pkgname-hivis.out
+++ b/testjson/testdata/format/pkgname-hivis.out
@@ -1,0 +1,5 @@
+❌  testjson/internal/badmain (1ms)
+🔳  testjson/internal/empty (cached)
+✅  testjson/internal/good (cached)
+❌  testjson/internal/parallelfails (20ms)
+❌  testjson/internal/withfails (20ms)

--- a/testjson/testdata/format/pkgname-hivis.out
+++ b/testjson/testdata/format/pkgname-hivis.out
@@ -1,5 +1,5 @@
 ❌  testjson/internal/badmain (1ms)
-🔳  testjson/internal/empty (cached)
+➖  testjson/internal/empty (cached)
 ✅  testjson/internal/good (cached)
 ❌  testjson/internal/parallelfails (20ms)
 ❌  testjson/internal/withfails (20ms)


### PR DESCRIPTION
The default icons used in the pkgname output formats (∅,✓,𐄂) can be hard to spot when scrolling through test output.

This PR adds the ability to pick a higher-visiblity/contrast set of icons (🔳,✅,❌) by adding a `-hivis` suffix to either of the 'pkgname' style formats.