### PR TITLE
Fix need to save twice to trigger watch on OSX using Neovim

### DIFF
--- a/internal/filewatcher/watch.go
+++ b/internal/filewatcher/watch.go
@@ -236,7 +236,7 @@ type fsEventHandler struct {
 var floodThreshold = 250 * time.Millisecond
 
 func (h *fsEventHandler) handleEvent(event fsnotify.Event) error {
-	if event.Op&(fsnotify.Write|fsnotify.Create) == 0 {
+	if event.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Rename) == 0 {
 		return nil
 	}
 

--- a/internal/filewatcher/watch_test.go
+++ b/internal/filewatcher/watch_test.go
@@ -38,8 +38,9 @@ func TestFSEventHandler_HandleEvent(t *testing.T) {
 
 	var testCases = []testCase{
 		{
-			name:  "Op is rename",
-			event: fsnotify.Event{Op: fsnotify.Rename, Name: "file_test.go"},
+			name:        "Op is rename",
+			event:       fsnotify.Event{Op: fsnotify.Rename, Name: "file_test.go"},
+			expectedRun: true,
 		},
 		{
 			name:  "Op is remove",


### PR DESCRIPTION
On OSX (12.6.2) using Neovim (NVIM v0.8.2) the triggering event varies between `fsnotify.Rename` and `Create`.
This fix adds `fsnotify.Rename` to the events triggering a new test run.

*Before*
```
handling event "cors_middleware.go": RENAME
handling event "cors_middleware.go": CREATE

Running tests in ./.
exec: [go test -json ./.]
go test pid: 96495
✓  . (cached)

DONE 71 tests in 0.237s
```

*After*
```
handling event "cors_middleware.go": RENAME

Running tests in ./.
exec: [go test -json ./.]
go test pid: 95707
✓  . (cached)

DONE 71 tests in 0.245s
```