### PR TITLE
Ensure jsonfile is flushed before running post-run-command

### DIFF
--- a/cmd/handler_test.go
+++ b/cmd/handler_test.go
@@ -56,6 +56,8 @@ type bufferCloser struct {
 
 func (bufferCloser) Close() error { return nil }
 
+func (bufferCloser) Sync() error { return nil }
+
 func TestEventHandler_Event_WithMissingActionFail(t *testing.T) {
 	buf := new(bufferCloser)
 	errBuf := new(bytes.Buffer)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -236,9 +236,11 @@ func run(opts *options) error {
 		IgnoreNonJSONOutputLines: opts.ignoreNonJSONOutputLines,
 	}
 	exec, err := testjson.ScanTestOutput(cfg)
+	handler.Flush()
 	if err != nil {
 		return finishRun(opts, exec, err)
 	}
+
 	exitErr := goTestProc.cmd.Wait()
 	if signum := atomic.LoadInt32(&goTestProc.signal); signum != 0 {
 		return finishRun(opts, exec, exitError{num: signalExitCode + int(signum)})
@@ -260,6 +262,7 @@ func run(opts *options) error {
 
 	cfg = testjson.ScanConfig{Execution: exec, Handler: handler}
 	exitErr = rerunFailed(ctx, opts, cfg)
+	handler.Flush()
 	if err := writeRerunFailsReport(opts, exec); err != nil {
 		return err
 	}

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -88,6 +88,7 @@ func runSingle(opts *options, dir string) (*testjson.Execution, error) {
 		Stop:    cancel,
 	}
 	exec, err := testjson.ScanTestOutput(cfg)
+	handler.Flush()
 	if err != nil {
 		return exec, finishRun(opts, exec, err)
 	}

--- a/testjson/format.go
+++ b/testjson/format.go
@@ -256,6 +256,8 @@ type FormatOptions struct {
 // NewEventFormatter returns a formatter for printing events.
 func NewEventFormatter(out io.Writer, format string, formatOpts FormatOptions) EventFormatter {
 	switch format {
+	case "none":
+		return eventFormatterFunc(func(TestEvent, *Execution) error { return nil })
 	case "debug":
 		return &formatAdapter{out, debugFormat}
 	case "standard-json":


### PR DESCRIPTION
While discussing the proposal in #303 I noticed the jsonfile is closed after running the `post-run-command`. In some cases, I think it's possible the post-run-command would read the file before all the contents of the file are flushed.

The test added in this commit seems to pass without these extra Flush, but from what I can tell there's no guarantee the file is sycned to disk without these new calls. Maybe that test would flake occasionally without these new calls to `Sync` ?