### PR TITLE
ci-matrix: improve description

### DIFF
--- a/cmd/tool/matrix/matrix.go
+++ b/cmd/tool/matrix/matrix.go
@@ -247,7 +247,7 @@ func writeMatrix(out io.Writer, buckets []bucket) error {
 			if len(bucket.Packages) > 1 {
 				extra = fmt.Sprintf(" and %d others", len(bucket.Packages)-1)
 			}
-			p.Description = fmt.Sprintf("partition %d - package %v%v",
+			p.Description = fmt.Sprintf("%d - %v%v",
 				p.ID, testjson.RelativePackagePath(bucket.Packages[0]), extra)
 		}
 

--- a/cmd/tool/matrix/matrix_test.go
+++ b/cmd/tool/matrix/matrix_test.go
@@ -226,19 +226,19 @@ func TestRun(t *testing.T) {
 var expectedMatrix = `{
   "include": [
     {
-      "description": "partition 0 - package pkg2",
+      "description": "0 - pkg2",
       "estimatedRuntime": "6s",
       "id": 0,
       "packages": "pkg2"
     },
     {
-      "description": "partition 1 - package pkg1",
+      "description": "1 - pkg1",
       "estimatedRuntime": "4s",
       "id": 1,
       "packages": "pkg1"
     },
     {
-      "description": "partition 2 - package pkg0 and 1 others",
+      "description": "2 - pkg0 and 1 others",
       "estimatedRuntime": "2s",
       "id": 2,
       "packages": "pkg0 other"


### PR DESCRIPTION
Github actions UI only shows the first few characters of the job name. The previous description resulted in the job names being mostly the same.

With this new description the more relevant parts of the name (the index and the primary package) should be more prominent.