### PR TITLE
Mention ci-matrix in the main help message

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -140,8 +140,9 @@ Formats:
     standard-verbose         standard go test -v format
 
 Commands:
-    %[1]s tool slowest   find or skip the slowest tests
-    %[1]s help           print this help next
+    %[1]s tool ci-matrix   use previous test runtime to place packages into optimal buckets
+    %[1]s tool slowest     find or skip the slowest tests
+    %[1]s help             print this help next
 `, name)
 }
 

--- a/cmd/testdata/gotestsum-help-text
+++ b/cmd/testdata/gotestsum-help-text
@@ -39,5 +39,6 @@ Formats:
     standard-verbose         standard go test -v format
 
 Commands:
-    gotestsum tool slowest   find or skip the slowest tests
-    gotestsum help           print this help next
+    gotestsum tool ci-matrix   use previous test runtime to place packages into optimal buckets
+    gotestsum tool slowest     find or skip the slowest tests
+    gotestsum help             print this help next


### PR DESCRIPTION
The `gotestsum tool ci-matrix` was not mentioned in the main help message. I have found this feature only accidentally :-)

Add the command to the main help message which is printed via `gotestsum help`:

```
$ gotestsum help
...
Commands:
    ./gotestsum tool ci-matrix   use previous test runtime to place packages into optimal buckets
    ./gotestsum tool slowest     find or skip the slowest tests
    ./gotestsum help             print this help next
``` 