### PR TITLE
Use io.Writer in formatters

### DIFF
--- a/internal/junitxml/report.go
+++ b/internal/junitxml/report.go
@@ -3,6 +3,7 @@
 package junitxml
 
 import (
+	"bytes"
 	"encoding/xml"
 	"fmt"
 	"io"
@@ -172,10 +173,12 @@ func packageTestCases(pkg *testjson.Package, formatClassname FormatFunc) []JUnit
 	cases := []JUnitTestCase{}
 
 	if pkg.TestMainFailed() {
+		var buf bytes.Buffer
+		pkg.WriteOutputTo(&buf, 0) //nolint:errcheck
 		jtc := newJUnitTestCase(testjson.TestCase{Test: "TestMain"}, formatClassname)
 		jtc.Failure = &JUnitFailure{
 			Message:  "Failed",
-			Contents: pkg.Output(0),
+			Contents: buf.String(),
 		}
 		cases = append(cases, jtc)
 	}

--- a/testjson/execution.go
+++ b/testjson/execution.go
@@ -154,8 +154,18 @@ func (p *Package) LastFailedByName(name string) TestCase {
 // Output returns the full test output for a test.
 //
 // Unlike OutputLines() it does not return lines from subtests in some cases.
+// TODO: remove
 func (p *Package) Output(id int) string {
 	return strings.Join(p.output[id], "")
+}
+
+func (p *Package) WriteOutputTo(out io.StringWriter, id int) error {
+	for _, v := range p.output[id] {
+		if _, err := out.WriteString(v); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // OutputLines returns the full test output for a test as a slice of strings.

--- a/testjson/execution.go
+++ b/testjson/execution.go
@@ -151,14 +151,15 @@ func (p *Package) LastFailedByName(name string) TestCase {
 	return TestCase{}
 }
 
-// Output returns the full test output for a test.
+// Output returns the full test output for a test. Unlike OutputLines() it does
+// not return lines from subtests in some cases.
 //
-// Unlike OutputLines() it does not return lines from subtests in some cases.
-// TODO: remove
+// Deprecated: use WriteOutputTo to avoid lots of allocation
 func (p *Package) Output(id int) string {
 	return strings.Join(p.output[id], "")
 }
 
+// WriteOutputTo writes the output for TestCase with id to out.
 func (p *Package) WriteOutputTo(out io.StringWriter, id int) error {
 	for _, v := range p.output[id] {
 		if _, err := out.WriteString(v); err != nil {

--- a/testjson/format_test.go
+++ b/testjson/format_test.go
@@ -63,12 +63,6 @@ func patchPkgPathPrefix(t *testing.T, val string) {
 	})
 }
 
-func withAdapter(format func(TestEvent, *Execution) string) func(io.Writer) EventFormatter {
-	return func(out io.Writer) EventFormatter {
-		return &formatAdapter{out: out, format: format}
-	}
-}
-
 func TestFormats_DefaultGoTestJson(t *testing.T) {
 	type testCase struct {
 		name        string
@@ -94,7 +88,7 @@ func TestFormats_DefaultGoTestJson(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:        "testname",
-			format:      withAdapter(testNameFormat),
+			format:      testNameFormat,
 			expectedOut: "format/testname.out",
 		},
 		{
@@ -174,7 +168,7 @@ func TestFormats_Coverage(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:        "testname",
-			format:      withAdapter(testNameFormat),
+			format:      testNameFormat,
 			expectedOut: "format/testname-coverage.out",
 		},
 		{
@@ -228,7 +222,7 @@ func TestFormats_Shuffle(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:        "testname",
-			format:      withAdapter(testNameFormat),
+			format:      testNameFormat,
 			expectedOut: "format/testname-shuffle.out",
 		},
 		{

--- a/testjson/format_test.go
+++ b/testjson/format_test.go
@@ -99,7 +99,7 @@ func TestFormats_DefaultGoTestJson(t *testing.T) {
 		},
 		{
 			name:        "dots-v1",
-			format:      withAdapter(dotsFormatV1),
+			format:      dotsFormatV1,
 			expectedOut: "format/dots-v1.out",
 		},
 		{
@@ -124,7 +124,7 @@ func TestFormats_DefaultGoTestJson(t *testing.T) {
 		},
 		{
 			name:        "standard-quiet",
-			format:      withAdapter(standardQuietFormat),
+			format:      standardQuietFormat,
 			expectedOut: "format/standard-quiet.out",
 		},
 		{
@@ -183,7 +183,7 @@ func TestFormats_Coverage(t *testing.T) {
 		},
 		{
 			name:        "standard-quiet",
-			format:      withAdapter(standardQuietFormat),
+			format:      standardQuietFormat,
 			expectedOut: "format/standard-quiet-coverage.out",
 		},
 	}
@@ -235,7 +235,7 @@ func TestFormats_Shuffle(t *testing.T) {
 		},
 		{
 			name:        "standard-quiet",
-			format:      withAdapter(standardQuietFormat),
+			format:      standardQuietFormat,
 			expectedOut: "format/standard-quiet-shuffle.out",
 		},
 	}

--- a/testjson/format_test.go
+++ b/testjson/format_test.go
@@ -103,18 +103,24 @@ func TestFormats_DefaultGoTestJson(t *testing.T) {
 			expectedOut: "format/dots-v1.out",
 		},
 		{
-			name:        "pkgname",
-			format:      withAdapter(pkgNameFormat(FormatOptions{})),
+			name: "pkgname",
+			format: func(out io.Writer) EventFormatter {
+				return pkgNameFormat(out, FormatOptions{})
+			},
 			expectedOut: "format/pkgname.out",
 		},
 		{
-			name:        "pkgname-hivis",
-			format:      withAdapter(pkgNameFormat(FormatOptions{UseHiVisibilityIcons: true})),
+			name: "pkgname with hivis",
+			format: func(out io.Writer) EventFormatter {
+				return pkgNameFormat(out, FormatOptions{UseHiVisibilityIcons: true})
+			},
 			expectedOut: "format/pkgname-hivis.out",
 		},
 		{
-			name:        "pkgname",
-			format:      withAdapter(pkgNameFormat(FormatOptions{HideEmptyPackages: true})),
+			name: "pkgname with hide-empty",
+			format: func(out io.Writer) EventFormatter {
+				return pkgNameFormat(out, FormatOptions{HideEmptyPackages: true})
+			},
 			expectedOut: "format/pkgname-hide-empty.out",
 		},
 		{
@@ -172,8 +178,10 @@ func TestFormats_Coverage(t *testing.T) {
 			expectedOut: "format/testname-coverage.out",
 		},
 		{
-			name:        "pkgname",
-			format:      withAdapter(pkgNameFormat(FormatOptions{})),
+			name: "pkgname",
+			format: func(out io.Writer) EventFormatter {
+				return pkgNameFormat(out, FormatOptions{})
+			},
 			expectedOut: "format/pkgname-coverage.out",
 		},
 		{
@@ -224,8 +232,10 @@ func TestFormats_Shuffle(t *testing.T) {
 			expectedOut: "format/testname-shuffle.out",
 		},
 		{
-			name:        "pkgname",
-			format:      withAdapter(pkgNameFormat(FormatOptions{})),
+			name: "pkgname",
+			format: func(out io.Writer) EventFormatter {
+				return pkgNameFormat(out, FormatOptions{})
+			},
 			expectedOut: "format/pkgname-shuffle.out",
 		},
 		{


### PR DESCRIPTION
PR #79 first introduced support for writing output directly to an `io.Writer` instead of creating large strings in memory. PR #313 added `eventFormatterFunc` so that formatters could be implemented as closures without needing a separate struct type for each.

This PR converts all the formatters to use this new type. There are still a few places where strings are constructed, but all of those strings should be small. The large strings (output from running tests) should be written directly to stdout, avoiding the need to allocate large strings that are discarded immediately after writing them.