### PR TITLE
ci: update goreleaser 1.7.0 to 1.17.0 for windows/arm64

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,8 +68,8 @@ commands:
       - run:
           name: Install goreleaser
           command: |
-            wget https://github.com/goreleaser/goreleaser/releases/download/v1.7.0/goreleaser_Linux_x86_64.tar.gz
-            echo "e74934e7571991522324642ac7b032310f04baf192ce2a54db1dc323b97bcd7d  goreleaser_Linux_x86_64.tar.gz" > checksum.txt
+            wget https://github.com/goreleaser/goreleaser/releases/download/v1.17.0/goreleaser_Linux_x86_64.tar.gz
+            echo "9fb13d0b9611794da8d71688a50b1f2ea221fcd5f2f4ad529f8b45ee909b2371  goreleaser_Linux_x86_64.tar.gz" > checksum.txt
             sha256sum -c checksum.txt
             tar -xf goreleaser_Linux_x86_64.tar.gz
             mkdir -p ./bin
@@ -98,13 +98,13 @@ jobs:
           steps:
             run:
               name: build binaries
-              command: bin/goreleaser --rm-dist --snapshot --config .project/goreleaser.yml
+              command: bin/goreleaser --clean --snapshot --config .project/goreleaser.yml
       - when:
           condition: << parameters.publish >>
           steps:
             run:
               name: build and publish binaries
-              command: bin/goreleaser --rm-dist --skip-validate --config .project/goreleaser.yml
+              command: bin/goreleaser --clean --skip-validate --config .project/goreleaser.yml
       - store_artifacts:
           path: ./dist
           destination: dist


### PR DESCRIPTION
Close https://github.com/gotestyourself/gotestsum/issues/323

I've confirmed the issue has been solved by updating goreleaser in my laptop.

```console
$ goreleaser --version
goreleaser version 1.17.0
commit: ffefd6c4ae257d2e9aeccb5786ba66401cc1bd78
built at: 2023-04-10T11:56:39Z
built by: goreleaser
goos: darwin
goarch: arm64
module version: v1.17.0, checksum: h1:CcA7EOcljdYhpEY2MUI1je6swCTCAlubxZk1VCbPKBY=

https://goreleaser.com
```

```console
$ goreleaser --clean --snapshot --config .project/goreleaser.yml
  • starting release...
  • loading config file                              file=.project/goreleaser.yml
  • loading environment variables
  • getting and validating git state
    • building...                                    commit=6723d7d1d70e3e77d1032a027b3d87b8fb88be2d latest tag=v1.10.0
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • snapshotting
    • building snapshot...                           version=1.10.0-SNAPSHOT-6723d7d
  • checking distribution directory
    • cleaning dist
  • loading go mod information
    • took: 1s
  • build prerequisites
  • writing effective config file
    • writing                                        config=dist/config.yaml
  • building binaries
    • building                                       binary=dist/gotestsum_linux_arm_6/gotestsum
    • building                                       binary=dist/gotestsum_windows_amd64_v1/gotestsum.exe
    • building                                       binary=dist/gotestsum_windows_arm_6/gotestsum.exe
    • building                                       binary=dist/gotestsum_linux_amd64_v1/gotestsum
    • building                                       binary=dist/gotestsum_linux_arm64/gotestsum
    • building                                       binary=dist/gotestsum_darwin_arm64/gotestsum
    • building                                       binary=dist/gotestsum_darwin_amd64_v1/gotestsum
    • building                                       binary=dist/gotestsum_freebsd_arm64/gotestsum
    • building                                       binary=dist/gotestsum_windows_arm64/gotestsum.exe
    • building                                       binary=dist/gotestsum_freebsd_amd64_v1/gotestsum
    • building                                       binary=dist/gotestsum_linux_s390x/gotestsum
    • building                                       binary=dist/gotestsum_linux_ppc64le/gotestsum
    • took: 4s
  • archives
    • creating                                       archive=dist/gotestsum_1.10.0-SNAPSHOT-6723d7d_windows_arm64.tar.gz
    • creating                                       archive=dist/gotestsum_1.10.0-SNAPSHOT-6723d7d_freebsd_arm64.tar.gz
    • creating                                       archive=dist/gotestsum_1.10.0-SNAPSHOT-6723d7d_darwin_arm64.tar.gz
    • creating                                       archive=dist/gotestsum_1.10.0-SNAPSHOT-6723d7d_darwin_amd64.tar.gz
    • creating                                       archive=dist/gotestsum_1.10.0-SNAPSHOT-6723d7d_windows_amd64.tar.gz
    • creating                                       archive=dist/gotestsum_1.10.0-SNAPSHOT-6723d7d_linux_amd64.tar.gz
    • creating                                       archive=dist/gotestsum_1.10.0-SNAPSHOT-6723d7d_linux_arm64.tar.gz
    • creating                                       archive=dist/gotestsum_1.10.0-SNAPSHOT-6723d7d_linux_ppc64le.tar.gz
    • creating                                       archive=dist/gotestsum_1.10.0-SNAPSHOT-6723d7d_linux_armv6.tar.gz
    • creating                                       archive=dist/gotestsum_1.10.0-SNAPSHOT-6723d7d_linux_s390x.tar.gz
    • creating                                       archive=dist/gotestsum_1.10.0-SNAPSHOT-6723d7d_windows_armv6.tar.gz
    • creating                                       archive=dist/gotestsum_1.10.0-SNAPSHOT-6723d7d_freebsd_amd64.tar.gz
    • took: 1s
  • calculating checksums
  • storing release metadata
    • writing                                        file=dist/artifacts.json
    • writing                                        file=dist/metadata.json
  • release succeeded after 5s
```

The warning was disappeared and the asset for windows/arm64 was built.

```console
$ ls dist/gotestsum_windows_arm64/gotestsum.exe
dist/gotestsum_windows_arm64/gotestsum.exe
```