### PR TITLE
Don't treat debug messages as errors

### DIFF
--- a/testjson/execution.go
+++ b/testjson/execution.go
@@ -734,7 +734,7 @@ func readStderr(config ScanConfig, execution *Execution) error {
 		if err := config.Handler.Err(line); err != nil {
 			return fmt.Errorf("failed to handle stderr: %v", err)
 		}
-		if isGoModuleOutput(line) {
+		if isGoModuleOutput(line) || isGoDebugOutput(line) {
 			continue
 		}
 		if strings.HasPrefix(line, "warning:") {
@@ -755,6 +755,20 @@ func isGoModuleOutput(scannerText string) bool {
 		"go: downloading",
 		"go: extracting",
 		"go: finding",
+	}
+
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(scannerText, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func isGoDebugOutput(scannerText string) bool {
+	prefixes := []string{
+		"HASH",       // Printed when tests are running with `GODEBUG=gocachehash=1`.
+		"testcache:", // Printed when tests are running with `GODEBUG=gocachetest=1`.
 	}
 
 	for _, prefix := range prefixes {

--- a/testjson/execution.go
+++ b/testjson/execution.go
@@ -742,6 +742,7 @@ func readStderr(config ScanConfig, execution *Execution) error {
 		}
 		execution.addError(line)
 	}
+
 	if err := scanner.Err(); err != nil {
 		return fmt.Errorf("failed to scan stderr: %v", err)
 	}


### PR DESCRIPTION
Teaching `gotestsum` to recognize Golang cache debug output. When `gocachehash=1` or `gocachetest=1` debug options are enabled, output is sent to `stderr`. `gotestum` treats unrecognised `stderr` messages as errors what makes test suite run marked as failed.

Example of testing `gotestsum` repository without this PR. Each debug info line is treated as error:
```shell
$ GODEBUG=gocachehash=1,gocachetest=1 ./gotestsum
...
DONE 183 tests, 2 skipped, 13819 errors in 0.726s
```

After fixing the issue:
```shell
$ GODEBUG=gocachehash=1,gocachetest=1 ./gotestsum
...
DONE 183 tests, 2 skipped in 0.523s
```