### PR TITLE
Quote test names before they are used within the regex to rerun

### DIFF
--- a/cmd/rerunfails.go
+++ b/cmd/rerunfails.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"sort"
 
 	"gotest.tools/gotestsum/testjson"
@@ -137,9 +138,9 @@ func (r *failureRecorder) count() int {
 func goTestRunFlagForTestCase(test testjson.TestName) string {
 	if test.IsSubTest() {
 		root, sub := test.Split()
-		return "-test.run=^" + root + "$/^" + sub + "$"
+		return "-test.run=^" + regexp.QuoteMeta(root) + "$/^" + regexp.QuoteMeta(sub) + "$"
 	}
-	return "-test.run=^" + test.Name() + "$"
+	return "-test.run=^" + regexp.QuoteMeta(test.Name()) + "$"
 }
 
 func writeRerunFailsReport(opts *options, exec *testjson.Execution) error {

--- a/cmd/rerunfails_test.go
+++ b/cmd/rerunfails_test.go
@@ -77,6 +77,10 @@ func TestGoTestRunFlagFromTestCases(t *testing.T) {
 			input:    "TestOne/SubtestA",
 			expected: "-test.run=^TestOne$/^SubtestA$",
 		},
+		"sub test case with special characters": {
+			input:    "TestOne/Subtest(A)[100]",
+			expected: `-test.run=^TestOne$/^Subtest\(A\)\[100\]$`,
+		},
 	}
 
 	for name := range testCases {


### PR DESCRIPTION
Fixes #337: The (sub) test names were not quoted before being used within the regex passed to `-run` and therefore caused `go test` to mis-evaluate the expression if there were parentheses contained. Uses https://pkg.go.dev/regexp#QuoteMeta to make it work for a wider range of characters.