### PR TITLE
[ci-matrix] Distribute unknown packages between shards.

### DIFF
--- a/cmd/tool/matrix/matrix_test.go
+++ b/cmd/tool/matrix/matrix_test.go
@@ -67,6 +67,7 @@ func TestBucketPackages(t *testing.T) {
 	}
 
 	run := func(t *testing.T, tc testCase) {
+		t.Helper()
 		buckets := bucketPackages(timing, packages, tc.n)
 		assert.DeepEqual(t, buckets, tc.expected)
 	}
@@ -75,25 +76,25 @@ func TestBucketPackages(t *testing.T) {
 		{
 			n: 2,
 			expected: []bucket{
-				0: {Total: 4440 * ms, Packages: []string{"four", "two", "one", "five"}},
-				1: {Total: 4406 * ms, Packages: []string{"three", "six", "new2", "new1"}},
+				0: {Total: 4440 * ms, Packages: []string{"four", "two", "one", "five", "new2", "new1"}},
+				1: {Total: 4406 * ms, Packages: []string{"three", "six"}},
 			},
 		},
 		{
 			n: 3,
 			expected: []bucket{
 				0: {Total: 4000 * ms, Packages: []string{"four"}},
-				1: {Total: 3800 * ms, Packages: []string{"three"}},
-				2: {Total: 1046 * ms, Packages: []string{"six", "two", "one", "five", "new1", "new2"}},
+				1: {Total: 3800 * ms, Packages: []string{"three", "new1"}},
+				2: {Total: 1046 * ms, Packages: []string{"six", "two", "one", "five", "new2"}},
 			},
 		},
 		{
 			n: 4,
 			expected: []bucket{
-				0: {Total: 4000 * ms, Packages: []string{"four"}},
+				0: {Total: 4000 * ms, Packages: []string{"four", "new1"}},
 				1: {Total: 3800 * ms, Packages: []string{"three"}},
-				2: {Total: 606 * ms, Packages: []string{"six"}},
-				3: {Total: 440 * ms, Packages: []string{"two", "one", "five", "new2", "new1"}},
+				2: {Total: 606 * ms, Packages: []string{"six", "new2"}},
+				3: {Total: 440 * ms, Packages: []string{"two", "one", "five"}},
 			},
 		},
 		{
@@ -232,16 +233,16 @@ var expectedMatrix = `{
       "packages": "pkg2"
     },
     {
-      "description": "1 - pkg1",
+      "description": "1 - pkg1 and 1 others",
       "estimatedRuntime": "4s",
       "id": 1,
-      "packages": "pkg1"
+      "packages": "pkg1 other"
     },
     {
-      "description": "2 - pkg0 and 1 others",
+      "description": "2 - pkg0",
       "estimatedRuntime": "2s",
       "id": 2,
-      "packages": "pkg0 other"
+      "packages": "pkg0"
     }
   ]
 }`


### PR DESCRIPTION
Currently all new packages which are not in timing files are assigned to a single bucket with shortest duration. This happens because duration of "unknown" packages is set to 0 but in reality it might be longer. There are also empty packages with no tests which have 0s duration but there is little overhead to run those tests.

This patch changes how those are distributed between shards to avoid all all of them added to a single bucket. If package run duration is lower than threshold - assign it by using hash function instead of minimal bucket. Hashing function is consistent what means the same package is assigned to the same bucket if package's name and count of buckets is not changed. This helps to reuse go build cache.

Bucket name is retrieved by calculating md5 hash of package's  name, then taking part of hash, converting to integer and calculating modulus by buckets count. Only a part of hash is converted to integer to avoid overflow - converting md5 hex to integer might give a result bigger than `int64`. I've tested distribution of such method and it seems to be pretty balanced. The 1st column shows how many packages were assigned to the bucket.

```shell
$ go list ./... | gotestsum tool ci-matrix --timing-files="path_to_files/*.json" --partitions 16 --debug 2>debug.log
$ grep "bucket \d+" -Eo < debug.log  | sort | uniq -c
  76 bucket 0
  64 bucket 1
  70 bucket 10
  78 bucket 11
  75 bucket 12
  78 bucket 13
  55 bucket 14
  60 bucket 15
  59 bucket 2
  71 bucket 3
  59 bucket 4
  67 bucket 5
  78 bucket 6
  65 bucket 7
  67 bucket 8
  74 bucket 9
```

This approach can be used when sharding strategy is not updated on each test run but is reused for extended period (e.g. week) because new tests will be distributed among shards.