### PR TITLE
handle multiple levels in subtest regex generation

### DIFF
--- a/cmd/rerunfails.go
+++ b/cmd/rerunfails.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"regexp"
 	"sort"
+	"strings"
 
 	"gotest.tools/gotestsum/testjson"
 )
@@ -137,8 +138,18 @@ func (r *failureRecorder) count() int {
 
 func goTestRunFlagForTestCase(test testjson.TestName) string {
 	if test.IsSubTest() {
-		root, sub := test.Split()
-		return "-test.run=^" + regexp.QuoteMeta(root) + "$/^" + regexp.QuoteMeta(sub) + "$"
+		parts := strings.Split(string(test), "/")
+		var sb strings.Builder
+		sb.WriteString("-test.run=")
+		for i, p := range parts {
+			if i > 0 {
+				sb.WriteByte('/')
+			}
+			sb.WriteByte('^')
+			sb.WriteString(regexp.QuoteMeta(p))
+			sb.WriteByte('$')
+		}
+		return sb.String()
 	}
 	return "-test.run=^" + regexp.QuoteMeta(test.Name()) + "$"
 }

--- a/cmd/rerunfails_test.go
+++ b/cmd/rerunfails_test.go
@@ -81,6 +81,10 @@ func TestGoTestRunFlagFromTestCases(t *testing.T) {
 			input:    "TestOne/Subtest(A)[100]",
 			expected: `-test.run=^TestOne$/^Subtest\(A\)\[100\]$`,
 		},
+		"nested sub test case": {
+			input:    "TestOne/Nested/SubtestA",
+			expected: `-test.run=^TestOne$/^Nested$/^SubtestA$`,
+		},
 	}
 
 	for name := range testCases {


### PR DESCRIPTION
Addresses part of the issue in #341 