### PR TITLE
Add SIGUSR1 handler for sending SIGABRT to test run

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -481,7 +481,7 @@ const signalExitCode = 128
 
 func newSignalHandler(ctx context.Context, pid int, p *proc) {
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
+	signal.Notify(c, os.Interrupt, syscall.SIGUSR1)
 
 	go func() {
 		defer signal.Stop(c)
@@ -496,6 +496,11 @@ func newSignalHandler(ctx context.Context, pid int, p *proc) {
 			if err != nil {
 				log.Errorf("failed to find pid of 'go test': %v", err)
 				return
+			}
+
+			// send go test the SIGABRT signal to get a stack trace before exit
+			if ss, ok := s.(syscall.Signal); ok && ss == syscall.SIGUSR1 {
+				s = syscall.SIGABRT
 			}
 			if err := proc.Signal(s); err != nil {
 				log.Errorf("failed to interrupt 'go test': %v", err)


### PR DESCRIPTION
Related to #344

Let's see if this signal is supported on all the platforms that build in CI.