### PR TITLE
Add ENV var to toggle `--format-hivis`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ The `--format` flag or `GOTESTSUM_FORMAT` environment variable set the format th
 is used to print the test names, and possibly test output, as the tests run. Most
 outputs use color to highlight pass, fail, or skip.
 
-The `--format-hivis` flag changes the icons used by `pkgname` formats to higher
-visiblity unicode characters.
+The `--format-hivis` flag or `GOTESTSUM_HIVIS` environment variable changes the icons used by `pkgname` formats 
+to higher visiblity unicode characters.
 
 Commonly used formats (see `--help` for a full list):
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -63,7 +63,7 @@ func setupFlags(name string) (*pflag.FlagSet, *options) {
 	flags.BoolVar(&opts.formatOptions.HideEmptyPackages, "format-hide-empty-pkg",
 		false, "do not print empty packages in compact formats")
 	flags.BoolVar(&opts.formatOptions.UseHiVisibilityIcons, "format-hivis",
-		false, "use high visibility characters in some formats")
+		lookEnvBoolWithDefault("GOTESTSUM_HIVIS", false), "use high visibility characters in some formats")
 	flags.BoolVar(&opts.rawCommand, "raw-command", false,
 		"don't prepend 'go test -json' to the 'go test' command")
 	flags.BoolVar(&opts.ignoreNonJSONOutputLines, "ignore-non-json-output-lines", false,
@@ -149,6 +149,13 @@ Commands:
     %[1]s tool slowest   find or skip the slowest tests
     %[1]s help           print this help next
 `, name)
+}
+
+func lookEnvBoolWithDefault(key string, defValue bool) bool {
+	if value := os.Getenv(key); value != "" {
+		return value == "true"
+	}
+	return defValue
 }
 
 func lookEnvWithDefault(key, defValue string) string {


### PR DESCRIPTION
Adds an additional environment variable to toggle on the `--format-hivis` option rather than always need to pass as an argument to the CLI.