### PR TITLE
dotsv2: remove jitters entirely

### DIFF
--- a/internal/dotwriter/writer.go
+++ b/internal/dotwriter/writer.go
@@ -14,6 +14,7 @@ const ESC = 27
 
 // Writer buffers writes until Flush is called. Flush clears previously written
 // lines before writing new lines from the buffer.
+// The main logic is platform specific, see the related files.
 type Writer struct {
 	out       io.Writer
 	buf       bytes.Buffer
@@ -23,19 +24,6 @@ type Writer struct {
 // New returns a new Writer
 func New(out io.Writer) *Writer {
 	return &Writer{out: out}
-}
-
-// Flush the buffer, writing all buffered lines to out
-func (w *Writer) Flush() error {
-	if w.buf.Len() == 0 {
-		return nil
-	}
-	defer w.hideCursor()()
-	w.clearLines(w.lineCount)
-	w.lineCount = bytes.Count(w.buf.Bytes(), []byte{'\n'})
-	_, err := w.out.Write(w.buf.Bytes())
-	w.buf.Reset()
-	return err
 }
 
 // Write saves buf to a buffer

--- a/internal/dotwriter/writer_posix.go
+++ b/internal/dotwriter/writer_posix.go
@@ -4,17 +4,56 @@
 package dotwriter
 
 import (
+	"bytes"
 	"fmt"
-	"strings"
 )
 
-// clear the line and move the cursor up
-var clear = fmt.Sprintf("%c[%dA%c[2K", ESC, 1, ESC)
+// hide cursor
 var hide = fmt.Sprintf("%c[?25l", ESC)
+
+// show cursor
 var show = fmt.Sprintf("%c[?25h", ESC)
 
-func (w *Writer) clearLines(count int) {
-	_, _ = fmt.Fprint(w.out, strings.Repeat(clear, count))
+// Flush the buffer, writing all buffered lines to out
+func (w *Writer) Flush() error {
+	if w.buf.Len() == 0 {
+		return nil
+	}
+	// Hide cursor during write to avoid it moving around the screen
+	defer w.hideCursor()()
+
+	// Move up to the top of our last output.
+	w.up(w.lineCount)
+	lines := bytes.Split(w.buf.Bytes(), []byte{'\n'})
+	w.lineCount = len(lines) - 1 // Record how many lines we will write for the next Flush()
+	for i, line := range lines {
+		// For each line, write the contents and clear everything else on the line
+		_, err := w.out.Write(line)
+		if err != nil {
+			return err
+		}
+		w.clearRest()
+		// Add a newline if this isn't the last line
+		if i != len(lines)-1 {
+			_, err := w.out.Write([]byte{'\n'})
+			if err != nil {
+				return err
+			}
+		}
+	}
+	w.buf.Reset()
+	return nil
+}
+
+func (w *Writer) up(count int) {
+	if count == 0 {
+		return
+	}
+	_, _ = fmt.Fprintf(w.out, "%c[%dA", ESC, count)
+}
+
+func (w *Writer) clearRest() {
+	_, _ = fmt.Fprintf(w.out, "%c[0K", ESC)
 }
 
 // hideCursor hides the cursor and returns a function to restore the cursor back.

--- a/internal/dotwriter/writer_windows.go
+++ b/internal/dotwriter/writer_windows.go
@@ -4,6 +4,7 @@
 package dotwriter
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"strings"
@@ -33,6 +34,19 @@ type coord struct {
 type fdWriter interface {
 	io.Writer
 	Fd() uintptr
+}
+
+// Flush implementation on windows is not ideal; we clear the entire screen before writing, which can result in flashing output
+// Windows likely can adopt the same approach as posix if someone invests some effort
+func (w *Writer) Flush() error {
+	if w.buf.Len() == 0 {
+		return nil
+	}
+	w.clearLines(w.lineCount)
+	w.lineCount = bytes.Count(w.buf.Bytes(), []byte{'\n'})
+	_, err := w.out.Write(w.buf.Bytes())
+	w.buf.Reset()
+	return err
 }
 
 func (w *Writer) clearLines(count int) {
@@ -70,9 +84,4 @@ func isConsole(fd uintptr) bool {
 	var mode uint32
 	err := windows.GetConsoleMode(windows.Handle(fd), &mode)
 	return err == nil
-}
-
-// This may work on Windows but I am not sure how to do it and its optional. For now, just do nothing.
-func (w *Writer) hideCursor() func() {
-	return func() {}
 }

--- a/testjson/testdata/format/dots-v2.out
+++ b/testjson/testdata/format/dots-v2.out
@@ -1,1210 +1,1210 @@
-[?25l
-
-   1ms testjson/internal/badmain 
-
+[?25l[0K
+[0K
+   1ms testjson/internal/badmain [0K
+[0K
  0 tests, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-
+[0K[?25h[?25l[5A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+[0K
  0 tests, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good 
-
+[0K[?25h[?25l[6A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good [0K
+[0K
  1 tests, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ·
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ·[0K
+[0K
  1 tests, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ·
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ·[0K
+[0K
  2 tests, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ··
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ··[0K
+[0K
  2 tests, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ··
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ··[0K
+[0K
  3 tests, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ···
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ···[0K
+[0K
  3 tests, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ···
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ···[0K
+[0K
  4 tests, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ···↷
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ···↷[0K
+[0K
  4 tests, 1 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ···↷
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ···↷[0K
+[0K
  5 tests, 1 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ···↷↷
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ···↷↷[0K
+[0K
  5 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ···↷↷
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ···↷↷[0K
+[0K
  6 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ···↷↷·
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ···↷↷·[0K
+[0K
  6 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ···↷↷·
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ···↷↷·[0K
+[0K
  7 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ···↷↷·
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ···↷↷·[0K
+[0K
  7 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ···↷↷·
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ···↷↷·[0K
+[0K
  8 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ···↷↷·
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ···↷↷·[0K
+[0K
  8 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ···↷↷·
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ···↷↷·[0K
+[0K
  9 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ···↷↷·
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ···↷↷·[0K
+[0K
  9 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ···↷↷·
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ···↷↷·[0K
+[0K
  10 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ···↷↷·
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ···↷↷·[0K
+[0K
  11 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ···↷↷·
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ···↷↷·[0K
+[0K
  12 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ···↷↷·
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ···↷↷·[0K
+[0K
  13 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ···↷↷·
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ···↷↷·[0K
+[0K
  14 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ···↷↷·
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ···↷↷·[0K
+[0K
  15 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ···↷↷·
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ···↷↷·[0K
+[0K
  16 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ···↷↷·
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ···↷↷·[0K
+[0K
  17 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ···↷↷·
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ···↷↷·[0K
+[0K
  18 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ···↷↷··
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ···↷↷··[0K
+[0K
  18 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ···↷↷···
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ···↷↷···[0K
+[0K
  18 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ···↷↷····
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ···↷↷····[0K
+[0K
  18 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ···↷↷·····
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ···↷↷·····[0K
+[0K
  18 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ···↷↷······
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ···↷↷······[0K
+[0K
  18 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ···↷↷·······
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ···↷↷·······[0K
+[0K
  18 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ···↷↷········
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ···↷↷········[0K
+[0K
  18 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ···↷↷·········
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ···↷↷·········[0K
+[0K
  18 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ···↷↷··········
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ···↷↷··········[0K
+[0K
  18 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ···↷↷··········
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ···↷↷··········[0K
+[0K
  18 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ···↷↷···········
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ···↷↷···········[0K
+[0K
  18 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ···↷↷···········
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ···↷↷···········[0K
+[0K
  18 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ···↷↷···········
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ···↷↷···········[0K
+[0K
  18 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ···↷↷············
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ···↷↷············[0K
+[0K
  18 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-       testjson/internal/good ···↷↷·············
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+       testjson/internal/good ···↷↷·············[0K
+[0K
  18 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+[0K
  18 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-       testjson/internal/parallelfails 
-
+[0K[?25h[?25l[7A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+       testjson/internal/parallelfails [0K
+[0K
  19 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-       testjson/internal/parallelfails ·
-
+[0K[?25h[?25l[8A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+       testjson/internal/parallelfails ·[0K
+[0K
  19 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-       testjson/internal/parallelfails ·
-
+[0K[?25h[?25l[8A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+       testjson/internal/parallelfails ·[0K
+[0K
  20 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-       testjson/internal/parallelfails ··
-
+[0K[?25h[?25l[8A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+       testjson/internal/parallelfails ··[0K
+[0K
  20 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-       testjson/internal/parallelfails ··
-
+[0K[?25h[?25l[8A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+       testjson/internal/parallelfails ··[0K
+[0K
  21 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-       testjson/internal/parallelfails ···
-
+[0K[?25h[?25l[8A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+       testjson/internal/parallelfails ···[0K
+[0K
  21 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-       testjson/internal/parallelfails ···
-
+[0K[?25h[?25l[8A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+       testjson/internal/parallelfails ···[0K
+[0K
  22 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-       testjson/internal/parallelfails ····
-
+[0K[?25h[?25l[8A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+       testjson/internal/parallelfails ····[0K
+[0K
  22 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-       testjson/internal/parallelfails ····
-
+[0K[?25h[?25l[8A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+       testjson/internal/parallelfails ····[0K
+[0K
  23 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-       testjson/internal/parallelfails ····
-
+[0K[?25h[?25l[8A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+       testjson/internal/parallelfails ····[0K
+[0K
  23 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-       testjson/internal/parallelfails ····
-
+[0K[?25h[?25l[8A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+       testjson/internal/parallelfails ····[0K
+[0K
  24 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-       testjson/internal/parallelfails ····
-
+[0K[?25h[?25l[8A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+       testjson/internal/parallelfails ····[0K
+[0K
  24 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-       testjson/internal/parallelfails ····
-
+[0K[?25h[?25l[8A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+       testjson/internal/parallelfails ····[0K
+[0K
  25 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-       testjson/internal/parallelfails ····
-
+[0K[?25h[?25l[8A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+       testjson/internal/parallelfails ····[0K
+[0K
  25 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-       testjson/internal/parallelfails ····
-
+[0K[?25h[?25l[8A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+       testjson/internal/parallelfails ····[0K
+[0K
  26 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-       testjson/internal/parallelfails ····
-
+[0K[?25h[?25l[8A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+       testjson/internal/parallelfails ····[0K
+[0K
  27 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-       testjson/internal/parallelfails ····
-
+[0K[?25h[?25l[8A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+       testjson/internal/parallelfails ····[0K
+[0K
  27 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-       testjson/internal/parallelfails ····
-
+[0K[?25h[?25l[8A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+       testjson/internal/parallelfails ····[0K
+[0K
  28 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-       testjson/internal/parallelfails ····
-
+[0K[?25h[?25l[8A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+       testjson/internal/parallelfails ····[0K
+[0K
  28 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-       testjson/internal/parallelfails ····
-
+[0K[?25h[?25l[8A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+       testjson/internal/parallelfails ····[0K
+[0K
  29 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-       testjson/internal/parallelfails ····
-
+[0K[?25h[?25l[8A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+       testjson/internal/parallelfails ····[0K
+[0K
  29 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-       testjson/internal/parallelfails ····
-
+[0K[?25h[?25l[8A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+       testjson/internal/parallelfails ····[0K
+[0K
  30 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-       testjson/internal/parallelfails ····
-
+[0K[?25h[?25l[8A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+       testjson/internal/parallelfails ····[0K
+[0K
  30 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-       testjson/internal/parallelfails ····
-
+[0K[?25h[?25l[8A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+       testjson/internal/parallelfails ····[0K
+[0K
  30 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-       testjson/internal/parallelfails ····
-
+[0K[?25h[?25l[8A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+       testjson/internal/parallelfails ····[0K
+[0K
  30 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-       testjson/internal/parallelfails ····
-
+[0K[?25h[?25l[8A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+       testjson/internal/parallelfails ····[0K
+[0K
  30 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-       testjson/internal/parallelfails ····
-
+[0K[?25h[?25l[8A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+       testjson/internal/parallelfails ····[0K
+[0K
  30 tests, 2 skipped, 1 failure, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-       testjson/internal/parallelfails ····✖
-
+[0K[?25h[?25l[8A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+       testjson/internal/parallelfails ····✖[0K
+[0K
  30 tests, 2 skipped, 2 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-       testjson/internal/parallelfails ····✖✖
-
+[0K[?25h[?25l[8A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+       testjson/internal/parallelfails ····✖✖[0K
+[0K
  30 tests, 2 skipped, 3 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-       testjson/internal/parallelfails ····✖✖✖
-
+[0K[?25h[?25l[8A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+       testjson/internal/parallelfails ····✖✖✖[0K
+[0K
  30 tests, 2 skipped, 4 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-       testjson/internal/parallelfails ····✖✖✖✖
-
+[0K[?25h[?25l[8A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+       testjson/internal/parallelfails ····✖✖✖✖[0K
+[0K
  30 tests, 2 skipped, 5 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-       testjson/internal/parallelfails ····✖✖✖✖✖
-
+[0K[?25h[?25l[8A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+       testjson/internal/parallelfails ····✖✖✖✖✖[0K
+[0K
  30 tests, 2 skipped, 6 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-       testjson/internal/parallelfails ····✖✖✖✖✖
-
+[0K[?25h[?25l[8A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+       testjson/internal/parallelfails ····✖✖✖✖✖[0K
+[0K
  30 tests, 2 skipped, 6 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-       testjson/internal/parallelfails ····✖✖✖✖✖✖
-
+[0K[?25h[?25l[8A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+       testjson/internal/parallelfails ····✖✖✖✖✖✖[0K
+[0K
  30 tests, 2 skipped, 7 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-       testjson/internal/parallelfails ····✖✖✖✖✖✖
-
+[0K[?25h[?25l[8A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+       testjson/internal/parallelfails ····✖✖✖✖✖✖[0K
+[0K
  30 tests, 2 skipped, 7 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-       testjson/internal/parallelfails ····✖✖✖✖✖✖✖
-
+[0K[?25h[?25l[8A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+       testjson/internal/parallelfails ····✖✖✖✖✖✖✖[0K
+[0K
  30 tests, 2 skipped, 8 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-       testjson/internal/parallelfails ····✖✖✖✖✖✖✖
-
+[0K[?25h[?25l[8A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+       testjson/internal/parallelfails ····✖✖✖✖✖✖✖[0K
+[0K
  30 tests, 2 skipped, 8 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-       testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-
+[0K[?25h[?25l[8A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+       testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+[0K
  30 tests, 2 skipped, 9 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-
+[0K[?25h[?25l[8A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+[0K
  30 tests, 2 skipped, 9 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails 
-
+[0K[?25h[?25l[8A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails [0K
+[0K
  31 tests, 2 skipped, 9 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ·
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ·[0K
+[0K
  31 tests, 2 skipped, 9 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ·
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ·[0K
+[0K
  32 tests, 2 skipped, 9 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ··
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ··[0K
+[0K
  32 tests, 2 skipped, 9 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ··
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ··[0K
+[0K
  33 tests, 2 skipped, 9 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···[0K
+[0K
  33 tests, 2 skipped, 9 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···[0K
+[0K
  34 tests, 2 skipped, 9 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷[0K
+[0K
  34 tests, 3 skipped, 9 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷[0K
+[0K
  35 tests, 3 skipped, 9 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷[0K
+[0K
  35 tests, 4 skipped, 9 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷[0K
+[0K
  36 tests, 4 skipped, 9 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖[0K
+[0K
  36 tests, 4 skipped, 10 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖[0K
+[0K
  37 tests, 4 skipped, 10 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·[0K
+[0K
  37 tests, 4 skipped, 10 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·[0K
+[0K
  38 tests, 4 skipped, 10 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖[0K
+[0K
  38 tests, 4 skipped, 11 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖[0K
+[0K
  39 tests, 4 skipped, 11 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖[0K
+[0K
  39 tests, 4 skipped, 11 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖[0K
+[0K
  40 tests, 4 skipped, 11 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖[0K
+[0K
  40 tests, 4 skipped, 11 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖[0K
+[0K
  41 tests, 4 skipped, 11 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖[0K
+[0K
  41 tests, 4 skipped, 11 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖[0K
+[0K
  42 tests, 4 skipped, 11 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖[0K
+[0K
  43 tests, 4 skipped, 11 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖[0K
+[0K
  44 tests, 4 skipped, 11 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖[0K
+[0K
  45 tests, 4 skipped, 11 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖[0K
+[0K
  46 tests, 4 skipped, 11 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖[0K
+[0K
  47 tests, 4 skipped, 11 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖[0K
+[0K
  48 tests, 4 skipped, 11 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖[0K
+[0K
  49 tests, 4 skipped, 11 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖·
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖·[0K
+[0K
  49 tests, 4 skipped, 11 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖··
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖··[0K
+[0K
  49 tests, 4 skipped, 11 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖···
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖···[0K
+[0K
  49 tests, 4 skipped, 11 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖····
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖····[0K
+[0K
  49 tests, 4 skipped, 11 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖····✖
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖····✖[0K
+[0K
  49 tests, 4 skipped, 12 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖····✖·
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖····✖·[0K
+[0K
  49 tests, 4 skipped, 12 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖····✖··
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖····✖··[0K
+[0K
  49 tests, 4 skipped, 12 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖····✖··✖[0K
+[0K
  49 tests, 4 skipped, 13 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖····✖··✖[0K
+[0K
  50 tests, 4 skipped, 13 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖····✖··✖[0K
+[0K
  51 tests, 4 skipped, 13 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖····✖··✖[0K
+[0K
  52 tests, 4 skipped, 13 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖····✖··✖[0K
+[0K
  53 tests, 4 skipped, 13 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖····✖··✖[0K
+[0K
  54 tests, 4 skipped, 13 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖····✖··✖[0K
+[0K
  55 tests, 4 skipped, 13 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖····✖··✖[0K
+[0K
  56 tests, 4 skipped, 13 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖····✖··✖[0K
+[0K
  57 tests, 4 skipped, 13 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖····✖··✖[0K
+[0K
  58 tests, 4 skipped, 13 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖·
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖····✖··✖·[0K
+[0K
  58 tests, 4 skipped, 13 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖··
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖····✖··✖··[0K
+[0K
  58 tests, 4 skipped, 13 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖···
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖····✖··✖···[0K
+[0K
  58 tests, 4 skipped, 13 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖····
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖····✖··✖····[0K
+[0K
  58 tests, 4 skipped, 13 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖·····
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖····✖··✖·····[0K
+[0K
  58 tests, 4 skipped, 13 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖······
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖····✖··✖······[0K
+[0K
  58 tests, 4 skipped, 13 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖·······
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖····✖··✖·······[0K
+[0K
  58 tests, 4 skipped, 13 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖········
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖····✖··✖········[0K
+[0K
  58 tests, 4 skipped, 13 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖·········
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖····✖··✖·········[0K
+[0K
  58 tests, 4 skipped, 13 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖·········
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖····✖··✖·········[0K
+[0K
  59 tests, 4 skipped, 13 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖·········↷
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖····✖··✖·········↷[0K
+[0K
  59 tests, 5 skipped, 13 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖·········↷
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖····✖··✖·········↷[0K
+[0K
  59 tests, 5 skipped, 13 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖·········↷·
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖····✖··✖·········↷·[0K
+[0K
  59 tests, 5 skipped, 13 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖·········↷·
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖····✖··✖·········↷·[0K
+[0K
  59 tests, 5 skipped, 13 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖·········↷··
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖····✖··✖·········↷··[0K
+[0K
  59 tests, 5 skipped, 13 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖·········↷··
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖····✖··✖·········↷··[0K
+[0K
  59 tests, 5 skipped, 13 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖·········↷···
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+       testjson/internal/withfails ···↷↷✖·✖····✖··✖·········↷···[0K
+[0K
  59 tests, 5 skipped, 13 failures, 1 error
-[?25h[?25l[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K
-
-   1ms testjson/internal/badmain 
-    🖴  testjson/internal/empty 
-    🖴  testjson/internal/good ···↷↷·············
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖
-  20ms testjson/internal/withfails ···↷↷✖·✖····✖··✖·········↷···
-
+[0K[?25h[?25l[9A[0K
+[0K
+   1ms testjson/internal/badmain [0K
+    🖴  testjson/internal/empty [0K
+    🖴  testjson/internal/good ···↷↷·············[0K
+  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+  20ms testjson/internal/withfails ···↷↷✖·✖····✖··✖·········↷···[0K
+[0K
  59 tests, 5 skipped, 13 failures, 1 error
-[?25h
+[0K[?25h


### PR DESCRIPTION
As best I can tell, this fully fixes https://github.com/gotestyourself/gotestsum/issues/352

While there were a variety of workarounds I tried to fix this, which had some improvement, the real root cause is doing `clear screen; write`. This leaves some time where each cell in the terminal goes from `<something> -> empty -> <something>`, which leads to blinking.

Instead, we can write and clear as we go. This has the same end result, but avoids the intermediate step where we have an empty cell.

This PR is probably not acceptable as-is as it doesn't even compile on windows. Not sure the best steps there, I neither have experience with implementing this in windows nor a machine to test on. We could keep the old implementation for windows, possibly.