### PR TITLE
filewatcher: silence warning from os.Stat failures

### DIFF
--- a/internal/filewatcher/watch.go
+++ b/internal/filewatcher/watch.go
@@ -213,7 +213,7 @@ func handleDirCreated(watcher *fsnotify.Watcher, event fsnotify.Event) (handled 
 
 	fileInfo, err := os.Stat(event.Name)
 	if err != nil {
-		log.Warnf("failed to stat %s: %s", event.Name, err)
+		log.Debugf("failed to stat %s: %s", event.Name, err)
 		return false
 	}
 


### PR DESCRIPTION
Although unlikely, it is possible for os.Stat to fail in handleDirCreated. The two most likely causes are a symlink to a target that doesn't exist or a race condition with a process that deletes the path.

In any case, it isn't actionable by the user and causes no harm to ignore the error.

Refs: #370 