### PR TITLE
Add support for gotestsum on illumos/amd64

### DIFF
--- a/.project/goreleaser.yml
+++ b/.project/goreleaser.yml
@@ -13,6 +13,7 @@ builds:
       - freebsd
       - windows
       - linux
+      - illumos
     goarch:
       - amd64
       - arm64
@@ -35,6 +36,14 @@ builds:
       - goos: windows
         goarch: s390x
       - goos: windows
+        goarch: ppc64le
+      - goos: illumos
+        goarch: arm
+      - goos: illumos
+        goarch: arm64
+      - goos: illumos
+        goarch: s390x
+      - goos: illumos
         goarch: ppc64le
 
 checksum:

--- a/internal/filewatcher/term_illumos.go
+++ b/internal/filewatcher/term_illumos.go
@@ -1,0 +1,4 @@
+package filewatcher
+
+const tcGet = 0x540d
+const tcSet = 0x540e


### PR DESCRIPTION
Please consider adding support for illumos-based operating systems such as OmniOS, OpenIndiana, SmartOS, etc. I tested to make sure things build correctly and validated that the tool works correctly on a couple of versions of OmniOS. Addition of `internal/filewatcher/term_illumos.go` was necessary to correctly build, and I apologize, but these constants are not available from `golang.org/x/sys/unix`, thus I supplied literal values instead. These values have not changed in at least 20 years, likely much longer.