### PR TITLE
Improve warning message when stdin is not a terminal

### DIFF
--- a/internal/filewatcher/term_unix.go
+++ b/internal/filewatcher/term_unix.go
@@ -26,7 +26,8 @@ func newTerminal() *terminal {
 }
 
 // Start the terminal is non-blocking read mode. The terminal can be reset to
-// normal mode by calling Reset.
+// normal mode by calling Reset. If os.Stdin is not a terminal or cannot use
+// non-blocking reads then a warning is logged and the terminal is not reset.
 func (r *terminal) Start() {
 	if r == nil {
 		return
@@ -34,7 +35,7 @@ func (r *terminal) Start() {
 	fd := int(os.Stdin.Fd())
 	reset, err := enableNonBlockingRead(fd)
 	if err != nil {
-		log.Warnf("failed to put terminal (fd %d) into raw mode: %v", fd, err)
+		log.Warnf("no terminal input -- keyboard shortcuts disabled: %v", err)
 		return
 	}
 	r.reset = reset


### PR DESCRIPTION
As discussed in a [comment](https://github.com/gotestyourself/gotestsum/issues/370#issuecomment-1724656425), update the warning message to be slightly more useful to the user by mentioning the impact of the error rather than just the cause.

Because `go test` captures Stderr & Stdout and redirects Stdin, it provides a handy repro. Without this change:

```console
$ go test
Running tests in ./.
Watching 1 directories. Use Ctrl-c to to stop a run or exit.
WARN failed to put terminal (fd 0) into raw mode: operation not supported by device
```

With this change:

```console
$ go test
Watching 1 directories. Use Ctrl-c to to stop a run or exit.
WARN no terminal input -- keyboard shortcuts disabled: operation not supported by device
```

I am happy to change the text if the maintainers can suggest better wording.

Refs: #370

🤵🏻 