### PR TITLE
Used named constants instead of magic numbers in illumos-specific code

### DIFF
--- a/internal/filewatcher/term_illumos.go
+++ b/internal/filewatcher/term_illumos.go
@@ -1,4 +1,6 @@
 package filewatcher
 
-const tcGet = 0x540d
-const tcSet = 0x540e
+import "golang.org/x/sys/unix"
+
+const tcGet = unix.TCGETS
+const tcSet = unix.TCSETS


### PR DESCRIPTION
This is based on feedback from @smoynes. I validated that these constants are correctly selected with `GOOS=illumos` this makes the code more consistent with other already existing OS-specific code in the `filewatcher` package.