### PR TITLE
Update gotestsum retries to properly filter out parents when there is a a missing gap in the parent tree

### DIFF
--- a/testjson/execution.go
+++ b/testjson/execution.go
@@ -563,8 +563,15 @@ func FilterFailedUnique(tcs []TestCase) []TestCase {
 		if _, exists := parents[tc.Package]; !exists {
 			parents[tc.Package] = make(map[string]bool)
 		}
-		if parent := tc.Test.Parent(); parent != "" {
-			parents[tc.Package][parent] = true
+		currentTest := tc.Test
+		for {
+			parent := currentTest.Parent()
+			if parent == "" {
+				break
+			} else {
+				parents[tc.Package][parent] = true
+				currentTest = TestName(parent)
+			}
 		}
 		if _, exists := parents[tc.Package][tc.Test.Name()]; exists {
 			continue // tc is a parent of a failing subtest

--- a/testjson/execution.go
+++ b/testjson/execution.go
@@ -563,15 +563,9 @@ func FilterFailedUnique(tcs []TestCase) []TestCase {
 		if _, exists := parents[tc.Package]; !exists {
 			parents[tc.Package] = make(map[string]bool)
 		}
-		currentTest := tc.Test
-		for {
-			parent := currentTest.Parent()
-			if parent == "" {
-				break
-			} else {
-				parents[tc.Package][parent] = true
-				currentTest = TestName(parent)
-			}
+
+		for p := tc.Test.Parent(); p != ""; p = TestName(p).Parent() {
+			parents[tc.Package][p] = true
 		}
 		if _, exists := parents[tc.Package][tc.Test.Name()]; exists {
 			continue // tc is a parent of a failing subtest

--- a/testjson/execution_test.go
+++ b/testjson/execution_test.go
@@ -301,13 +301,16 @@ func TestFilterFailedUnique_MultipleNested(t *testing.T) {
 
 func TestFilterFailedUnique_NestedWithGaps(t *testing.T) {
 	input := []TestCase{
-		{ID: 2, Package: "pkg", Test: "TestParent/foo/bar/baz"},
-		{ID: 1, Package: "pkg", Test: "TestParent"},
+		{ID: 1, Package: "pkg", Test: "TestParent/foo/bar/baz"},
+		{ID: 2, Package: "pkg", Test: "TestParent"},
+		{ID: 3, Package: "pkg", Test: "TestParent1/foo/bar"},
+		{ID: 4, Package: "pkg", Test: "TestParent1"},
 	}
 	actual := FilterFailedUnique(input)
 
 	expected := []TestCase{
-		{ID: 2, Package: "pkg", Test: "TestParent/foo/bar/baz"},
+		{ID: 1, Package: "pkg", Test: "TestParent/foo/bar/baz"},
+		{ID: 3, Package: "pkg", Test: "TestParent1/foo/bar"},
 	}
 	cmpTestCase := cmp.AllowUnexported(TestCase{})
 	assert.DeepEqual(t, expected, actual, cmpTestCase)

--- a/testjson/execution_test.go
+++ b/testjson/execution_test.go
@@ -298,3 +298,17 @@ func TestFilterFailedUnique_MultipleNested(t *testing.T) {
 	cmpTestCase := cmp.AllowUnexported(TestCase{})
 	assert.DeepEqual(t, expected, actual, cmpTestCase)
 }
+
+func TestFilterFailedUnique_NestedWithGaps(t *testing.T) {
+	input := []TestCase{
+		{ID: 2, Package: "pkg", Test: "TestParent/foo/bar/baz"},
+		{ID: 1, Package: "pkg", Test: "TestParent"},
+	}
+	actual := FilterFailedUnique(input)
+
+	expected := []TestCase{
+		{ID: 2, Package: "pkg", Test: "TestParent/foo/bar/baz"},
+	}
+	cmpTestCase := cmp.AllowUnexported(TestCase{})
+	assert.DeepEqual(t, expected, actual, cmpTestCase)
+}


### PR DESCRIPTION
If someone creates a test name with `/` in the name, then it is possible to end up with a hierarchy with a gap. For example, if someone creates a subtest of `TestParent` with the name `child/grandchild` and it fails, then the two failing tests will be `TestParent` and `TestParent/child/grandchild`. This breaks `FilterFailedUnique` and will cause it not to filter out `TestParent` which means that all child tests will get rerun. This PR fixes this by updating the `parents` to include all the parents of the given test case. 

If you're curious for why someone would be doing this, I don't think there is any strong requirement for people to do this, but [personally I do it in hishtory](https://github.com/ddworken/hishtory/blob/9433bd6e944c4b59d487e740d271c1e4a63b5bb5/client/client_test.go#L62-L63) and I suspect I'm not the only person doing this. So it seems like a useful change. WDYT? 