### PR TITLE
dots-v2: fix jitteriness, again

### DIFF
--- a/internal/dotwriter/writer.go
+++ b/internal/dotwriter/writer.go
@@ -5,20 +5,15 @@ terminal.
 package dotwriter
 
 import (
-	"bytes"
 	"io"
 )
-
-// ESC is the ASCII code for escape character
-const ESC = 27
 
 // Writer buffers writes until Flush is called. Flush clears previously written
 // lines before writing new lines from the buffer.
 // The main logic is platform specific, see the related files.
 type Writer struct {
-	out       io.Writer
-	buf       bytes.Buffer
-	lineCount int
+	out             io.Writer
+	inProgressLines int
 }
 
 // New returns a new Writer
@@ -26,7 +21,17 @@ func New(out io.Writer) *Writer {
 	return &Writer{out: out}
 }
 
-// Write saves buf to a buffer
-func (w *Writer) Write(buf []byte) (int, error) {
-	return w.buf.Write(buf)
+func (w *Writer) Write(persistent []string, progressing []string) {
+	defer w.hideCursor()()
+	// Move up to the top of our last output.
+	up := w.inProgressLines
+	w.up(up)
+	for _, lines := range [][]string{persistent, progressing} {
+		for _, l := range lines {
+			w.write([]byte(l))
+			w.clearRest()
+			w.write([]byte{'\n'})
+		}
+	}
+	w.inProgressLines = len(progressing)
 }

--- a/internal/dotwriter/writer_posix.go
+++ b/internal/dotwriter/writer_posix.go
@@ -4,9 +4,11 @@
 package dotwriter
 
 import (
-	"bytes"
 	"fmt"
 )
+
+// ESC is the ASCII code for escape character
+const ESC = 27
 
 // hide cursor
 var hide = fmt.Sprintf("%c[?25l", ESC)
@@ -14,35 +16,8 @@ var hide = fmt.Sprintf("%c[?25l", ESC)
 // show cursor
 var show = fmt.Sprintf("%c[?25h", ESC)
 
-// Flush the buffer, writing all buffered lines to out
-func (w *Writer) Flush() error {
-	if w.buf.Len() == 0 {
-		return nil
-	}
-	// Hide cursor during write to avoid it moving around the screen
-	defer w.hideCursor()()
-
-	// Move up to the top of our last output.
-	w.up(w.lineCount)
-	lines := bytes.Split(w.buf.Bytes(), []byte{'\n'})
-	w.lineCount = len(lines) - 1 // Record how many lines we will write for the next Flush()
-	for i, line := range lines {
-		// For each line, write the contents and clear everything else on the line
-		_, err := w.out.Write(line)
-		if err != nil {
-			return err
-		}
-		w.clearRest()
-		// Add a newline if this isn't the last line
-		if i != len(lines)-1 {
-			_, err := w.out.Write([]byte{'\n'})
-			if err != nil {
-				return err
-			}
-		}
-	}
-	w.buf.Reset()
-	return nil
+func (w *Writer) write(b []byte) {
+	_, _ = w.out.Write(b)
 }
 
 func (w *Writer) up(count int) {

--- a/internal/dotwriter/writer_windows.go
+++ b/internal/dotwriter/writer_windows.go
@@ -42,8 +42,8 @@ func (w *Writer) Flush() error {
 	if w.buf.Len() == 0 {
 		return nil
 	}
-	w.clearLines(w.lineCount)
-	w.lineCount = bytes.Count(w.buf.Bytes(), []byte{'\n'})
+	w.clearLines(w.inProgressLines)
+	w.inProgressLines = bytes.Count(w.buf.Bytes(), []byte{'\n'})
 	_, err := w.out.Write(w.buf.Bytes())
 	w.buf.Reset()
 	return err

--- a/testjson/execution.go
+++ b/testjson/execution.go
@@ -109,6 +109,7 @@ type Package struct {
 	// output caused by a test timeout. This is necessary to work around a race
 	// condition in test2json. See https://github.com/golang/go/issues/57305.
 	testTimeoutPanicInTest string
+	skipped                bool
 }
 
 // Result returns if the package passed, failed, or was skipped because there
@@ -371,6 +372,8 @@ func (p *Package) addEvent(event TestEvent) {
 	case ActionPass, ActionFail:
 		p.action = event.Action
 		p.elapsed = elapsedDuration(event.Elapsed)
+	case ActionSkip:
+		p.skipped = true
 	case ActionOutput:
 		if coverage, ok := isCoverageOutput(event.Output); ok {
 			p.coverage = coverage

--- a/testjson/testdata/format/dots-v2.out
+++ b/testjson/testdata/format/dots-v2.out
@@ -1,1210 +1,597 @@
-[?25l[0K
-[0K
-   1ms testjson/internal/badmain [0K
+[?25l   1ms testjson/internal/badmain [0K
 [0K
  0 tests, 1 failure, 1 error
-[0K[?25h[?25l[5A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
+[?25h[?25l[3A    🖴  testjson/internal/empty [0K
 [0K
  0 tests, 1 failure, 1 error
-[0K[?25h[?25l[6A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good [0K
+[?25h[?25l[3A       testjson/internal/good [0K
 [0K
  1 tests, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ·[0K
+[?25h[?25l[4A       testjson/internal/good ·[0K
 [0K
  1 tests, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ·[0K
+[?25h[?25l[4A       testjson/internal/good ·[0K
 [0K
  2 tests, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ··[0K
+[?25h[?25l[4A       testjson/internal/good ··[0K
 [0K
  2 tests, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ··[0K
+[?25h[?25l[4A       testjson/internal/good ··[0K
 [0K
  3 tests, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ···[0K
+[?25h[?25l[4A       testjson/internal/good ···[0K
 [0K
  3 tests, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ···[0K
+[?25h[?25l[4A       testjson/internal/good ···[0K
 [0K
  4 tests, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ···↷[0K
+[?25h[?25l[4A       testjson/internal/good ···↷[0K
 [0K
  4 tests, 1 skipped, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ···↷[0K
+[?25h[?25l[4A       testjson/internal/good ···↷[0K
 [0K
  5 tests, 1 skipped, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ···↷↷[0K
+[?25h[?25l[4A       testjson/internal/good ···↷↷[0K
 [0K
  5 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ···↷↷[0K
+[?25h[?25l[4A       testjson/internal/good ···↷↷[0K
 [0K
  6 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ···↷↷·[0K
+[?25h[?25l[4A       testjson/internal/good ···↷↷·[0K
 [0K
  6 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ···↷↷·[0K
+[?25h[?25l[4A       testjson/internal/good ···↷↷·[0K
 [0K
  7 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ···↷↷·[0K
+[?25h[?25l[4A       testjson/internal/good ···↷↷·[0K
 [0K
  7 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ···↷↷·[0K
+[?25h[?25l[4A       testjson/internal/good ···↷↷·[0K
 [0K
  8 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ···↷↷·[0K
+[?25h[?25l[4A       testjson/internal/good ···↷↷·[0K
 [0K
  8 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ···↷↷·[0K
+[?25h[?25l[4A       testjson/internal/good ···↷↷·[0K
 [0K
  9 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ···↷↷·[0K
+[?25h[?25l[4A       testjson/internal/good ···↷↷·[0K
 [0K
  9 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ···↷↷·[0K
+[?25h[?25l[4A       testjson/internal/good ···↷↷·[0K
 [0K
  10 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ···↷↷·[0K
+[?25h[?25l[4A       testjson/internal/good ···↷↷·[0K
 [0K
  11 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ···↷↷·[0K
+[?25h[?25l[4A       testjson/internal/good ···↷↷·[0K
 [0K
  12 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ···↷↷·[0K
+[?25h[?25l[4A       testjson/internal/good ···↷↷·[0K
 [0K
  13 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ···↷↷·[0K
+[?25h[?25l[4A       testjson/internal/good ···↷↷·[0K
 [0K
  14 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ···↷↷·[0K
+[?25h[?25l[4A       testjson/internal/good ···↷↷·[0K
 [0K
  15 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ···↷↷·[0K
+[?25h[?25l[4A       testjson/internal/good ···↷↷·[0K
 [0K
  16 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ···↷↷·[0K
+[?25h[?25l[4A       testjson/internal/good ···↷↷·[0K
 [0K
  17 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ···↷↷·[0K
+[?25h[?25l[4A       testjson/internal/good ···↷↷·[0K
 [0K
  18 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ···↷↷··[0K
+[?25h[?25l[4A       testjson/internal/good ···↷↷··[0K
 [0K
  18 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ···↷↷···[0K
+[?25h[?25l[4A       testjson/internal/good ···↷↷···[0K
 [0K
  18 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ···↷↷····[0K
+[?25h[?25l[4A       testjson/internal/good ···↷↷····[0K
 [0K
  18 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ···↷↷·····[0K
+[?25h[?25l[4A       testjson/internal/good ···↷↷·····[0K
 [0K
  18 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ···↷↷······[0K
+[?25h[?25l[4A       testjson/internal/good ···↷↷······[0K
 [0K
  18 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ···↷↷·······[0K
+[?25h[?25l[4A       testjson/internal/good ···↷↷·······[0K
 [0K
  18 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ···↷↷········[0K
+[?25h[?25l[4A       testjson/internal/good ···↷↷········[0K
 [0K
  18 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ···↷↷·········[0K
+[?25h[?25l[4A       testjson/internal/good ···↷↷·········[0K
 [0K
  18 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ···↷↷··········[0K
+[?25h[?25l[4A       testjson/internal/good ···↷↷··········[0K
 [0K
  18 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ···↷↷··········[0K
+[?25h[?25l[4A       testjson/internal/good ···↷↷··········[0K
 [0K
  18 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ···↷↷···········[0K
+[?25h[?25l[4A       testjson/internal/good ···↷↷···········[0K
 [0K
  18 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ···↷↷···········[0K
+[?25h[?25l[4A       testjson/internal/good ···↷↷···········[0K
 [0K
  18 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ···↷↷···········[0K
+[?25h[?25l[4A       testjson/internal/good ···↷↷···········[0K
 [0K
  18 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ···↷↷············[0K
+[?25h[?25l[4A       testjson/internal/good ···↷↷············[0K
 [0K
  18 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-       testjson/internal/good ···↷↷·············[0K
+[?25h[?25l[4A       testjson/internal/good ···↷↷·············[0K
 [0K
  18 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
+[?25h[?25l[4A    🖴  testjson/internal/good ···↷↷·············[0K
 [0K
  18 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[7A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-       testjson/internal/parallelfails [0K
+[?25h[?25l[3A       testjson/internal/parallelfails [0K
 [0K
  19 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[8A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-       testjson/internal/parallelfails ·[0K
+[?25h[?25l[4A       testjson/internal/parallelfails ·[0K
 [0K
  19 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[8A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-       testjson/internal/parallelfails ·[0K
+[?25h[?25l[4A       testjson/internal/parallelfails ·[0K
 [0K
  20 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[8A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-       testjson/internal/parallelfails ··[0K
+[?25h[?25l[4A       testjson/internal/parallelfails ··[0K
 [0K
  20 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[8A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-       testjson/internal/parallelfails ··[0K
+[?25h[?25l[4A       testjson/internal/parallelfails ··[0K
 [0K
  21 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[8A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-       testjson/internal/parallelfails ···[0K
+[?25h[?25l[4A       testjson/internal/parallelfails ···[0K
 [0K
  21 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[8A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-       testjson/internal/parallelfails ···[0K
+[?25h[?25l[4A       testjson/internal/parallelfails ···[0K
 [0K
  22 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[8A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-       testjson/internal/parallelfails ····[0K
+[?25h[?25l[4A       testjson/internal/parallelfails ····[0K
 [0K
  22 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[8A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-       testjson/internal/parallelfails ····[0K
+[?25h[?25l[4A       testjson/internal/parallelfails ····[0K
 [0K
  23 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[8A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-       testjson/internal/parallelfails ····[0K
+[?25h[?25l[4A       testjson/internal/parallelfails ····[0K
 [0K
  23 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[8A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-       testjson/internal/parallelfails ····[0K
+[?25h[?25l[4A       testjson/internal/parallelfails ····[0K
 [0K
  24 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[8A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-       testjson/internal/parallelfails ····[0K
+[?25h[?25l[4A       testjson/internal/parallelfails ····[0K
 [0K
  24 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[8A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-       testjson/internal/parallelfails ····[0K
+[?25h[?25l[4A       testjson/internal/parallelfails ····[0K
 [0K
  25 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[8A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-       testjson/internal/parallelfails ····[0K
+[?25h[?25l[4A       testjson/internal/parallelfails ····[0K
 [0K
  25 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[8A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-       testjson/internal/parallelfails ····[0K
+[?25h[?25l[4A       testjson/internal/parallelfails ····[0K
 [0K
  26 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[8A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-       testjson/internal/parallelfails ····[0K
+[?25h[?25l[4A       testjson/internal/parallelfails ····[0K
 [0K
  27 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[8A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-       testjson/internal/parallelfails ····[0K
+[?25h[?25l[4A       testjson/internal/parallelfails ····[0K
 [0K
  27 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[8A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-       testjson/internal/parallelfails ····[0K
+[?25h[?25l[4A       testjson/internal/parallelfails ····[0K
 [0K
  28 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[8A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-       testjson/internal/parallelfails ····[0K
+[?25h[?25l[4A       testjson/internal/parallelfails ····[0K
 [0K
  28 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[8A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-       testjson/internal/parallelfails ····[0K
+[?25h[?25l[4A       testjson/internal/parallelfails ····[0K
 [0K
  29 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[8A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-       testjson/internal/parallelfails ····[0K
+[?25h[?25l[4A       testjson/internal/parallelfails ····[0K
 [0K
  29 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[8A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-       testjson/internal/parallelfails ····[0K
+[?25h[?25l[4A       testjson/internal/parallelfails ····[0K
 [0K
  30 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[8A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-       testjson/internal/parallelfails ····[0K
+[?25h[?25l[4A       testjson/internal/parallelfails ····[0K
 [0K
  30 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[8A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-       testjson/internal/parallelfails ····[0K
+[?25h[?25l[4A       testjson/internal/parallelfails ····[0K
 [0K
  30 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[8A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-       testjson/internal/parallelfails ····[0K
+[?25h[?25l[4A       testjson/internal/parallelfails ····[0K
 [0K
  30 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[8A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-       testjson/internal/parallelfails ····[0K
+[?25h[?25l[4A       testjson/internal/parallelfails ····[0K
 [0K
  30 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[8A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-       testjson/internal/parallelfails ····[0K
+[?25h[?25l[4A       testjson/internal/parallelfails ····[0K
 [0K
  30 tests, 2 skipped, 1 failure, 1 error
-[0K[?25h[?25l[8A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-       testjson/internal/parallelfails ····✖[0K
+[?25h[?25l[4A       testjson/internal/parallelfails ····✖[0K
 [0K
  30 tests, 2 skipped, 2 failures, 1 error
-[0K[?25h[?25l[8A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-       testjson/internal/parallelfails ····✖✖[0K
+[?25h[?25l[4A       testjson/internal/parallelfails ····✖✖[0K
 [0K
  30 tests, 2 skipped, 3 failures, 1 error
-[0K[?25h[?25l[8A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-       testjson/internal/parallelfails ····✖✖✖[0K
+[?25h[?25l[4A       testjson/internal/parallelfails ····✖✖✖[0K
 [0K
  30 tests, 2 skipped, 4 failures, 1 error
-[0K[?25h[?25l[8A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-       testjson/internal/parallelfails ····✖✖✖✖[0K
+[?25h[?25l[4A       testjson/internal/parallelfails ····✖✖✖✖[0K
 [0K
  30 tests, 2 skipped, 5 failures, 1 error
-[0K[?25h[?25l[8A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-       testjson/internal/parallelfails ····✖✖✖✖✖[0K
+[?25h[?25l[4A       testjson/internal/parallelfails ····✖✖✖✖✖[0K
 [0K
  30 tests, 2 skipped, 6 failures, 1 error
-[0K[?25h[?25l[8A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-       testjson/internal/parallelfails ····✖✖✖✖✖[0K
+[?25h[?25l[4A       testjson/internal/parallelfails ····✖✖✖✖✖[0K
 [0K
  30 tests, 2 skipped, 6 failures, 1 error
-[0K[?25h[?25l[8A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-       testjson/internal/parallelfails ····✖✖✖✖✖✖[0K
+[?25h[?25l[4A       testjson/internal/parallelfails ····✖✖✖✖✖✖[0K
 [0K
  30 tests, 2 skipped, 7 failures, 1 error
-[0K[?25h[?25l[8A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-       testjson/internal/parallelfails ····✖✖✖✖✖✖[0K
+[?25h[?25l[4A       testjson/internal/parallelfails ····✖✖✖✖✖✖[0K
 [0K
  30 tests, 2 skipped, 7 failures, 1 error
-[0K[?25h[?25l[8A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-       testjson/internal/parallelfails ····✖✖✖✖✖✖✖[0K
+[?25h[?25l[4A       testjson/internal/parallelfails ····✖✖✖✖✖✖✖[0K
 [0K
  30 tests, 2 skipped, 8 failures, 1 error
-[0K[?25h[?25l[8A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-       testjson/internal/parallelfails ····✖✖✖✖✖✖✖[0K
+[?25h[?25l[4A       testjson/internal/parallelfails ····✖✖✖✖✖✖✖[0K
 [0K
  30 tests, 2 skipped, 8 failures, 1 error
-[0K[?25h[?25l[8A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-       testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+[?25h[?25l[4A       testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
 [0K
  30 tests, 2 skipped, 9 failures, 1 error
-[0K[?25h[?25l[8A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
+[?25h[?25l[4A  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
 [0K
  30 tests, 2 skipped, 9 failures, 1 error
-[0K[?25h[?25l[8A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails [0K
+[?25h[?25l[3A       testjson/internal/withfails [0K
 [0K
  31 tests, 2 skipped, 9 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ·[0K
+[?25h[?25l[4A       testjson/internal/withfails ·[0K
 [0K
  31 tests, 2 skipped, 9 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ·[0K
+[?25h[?25l[4A       testjson/internal/withfails ·[0K
 [0K
  32 tests, 2 skipped, 9 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ··[0K
+[?25h[?25l[4A       testjson/internal/withfails ··[0K
 [0K
  32 tests, 2 skipped, 9 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ··[0K
+[?25h[?25l[4A       testjson/internal/withfails ··[0K
 [0K
  33 tests, 2 skipped, 9 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···[0K
+[?25h[?25l[4A       testjson/internal/withfails ···[0K
 [0K
  33 tests, 2 skipped, 9 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···[0K
+[?25h[?25l[4A       testjson/internal/withfails ···[0K
 [0K
  34 tests, 2 skipped, 9 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷[0K
 [0K
  34 tests, 3 skipped, 9 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷[0K
 [0K
  35 tests, 3 skipped, 9 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷[0K
 [0K
  35 tests, 4 skipped, 9 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷[0K
 [0K
  36 tests, 4 skipped, 9 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖[0K
 [0K
  36 tests, 4 skipped, 10 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖[0K
 [0K
  37 tests, 4 skipped, 10 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·[0K
 [0K
  37 tests, 4 skipped, 10 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·[0K
 [0K
  38 tests, 4 skipped, 10 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖[0K
 [0K
  38 tests, 4 skipped, 11 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖[0K
 [0K
  39 tests, 4 skipped, 11 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖[0K
 [0K
  39 tests, 4 skipped, 11 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖[0K
 [0K
  40 tests, 4 skipped, 11 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖[0K
 [0K
  40 tests, 4 skipped, 11 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖[0K
 [0K
  41 tests, 4 skipped, 11 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖[0K
 [0K
  41 tests, 4 skipped, 11 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖[0K
 [0K
  42 tests, 4 skipped, 11 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖[0K
 [0K
  43 tests, 4 skipped, 11 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖[0K
 [0K
  44 tests, 4 skipped, 11 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖[0K
 [0K
  45 tests, 4 skipped, 11 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖[0K
 [0K
  46 tests, 4 skipped, 11 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖[0K
 [0K
  47 tests, 4 skipped, 11 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖[0K
 [0K
  48 tests, 4 skipped, 11 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖[0K
 [0K
  49 tests, 4 skipped, 11 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖·[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖·[0K
 [0K
  49 tests, 4 skipped, 11 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖··[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖··[0K
 [0K
  49 tests, 4 skipped, 11 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖···[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖···[0K
 [0K
  49 tests, 4 skipped, 11 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖····[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖····[0K
 [0K
  49 tests, 4 skipped, 11 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖····✖[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖····✖[0K
 [0K
  49 tests, 4 skipped, 12 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖····✖·[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖····✖·[0K
 [0K
  49 tests, 4 skipped, 12 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖····✖··[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖····✖··[0K
 [0K
  49 tests, 4 skipped, 12 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖····✖··✖[0K
 [0K
  49 tests, 4 skipped, 13 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖····✖··✖[0K
 [0K
  50 tests, 4 skipped, 13 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖····✖··✖[0K
 [0K
  51 tests, 4 skipped, 13 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖····✖··✖[0K
 [0K
  52 tests, 4 skipped, 13 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖····✖··✖[0K
 [0K
  53 tests, 4 skipped, 13 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖····✖··✖[0K
 [0K
  54 tests, 4 skipped, 13 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖····✖··✖[0K
 [0K
  55 tests, 4 skipped, 13 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖····✖··✖[0K
 [0K
  56 tests, 4 skipped, 13 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖····✖··✖[0K
 [0K
  57 tests, 4 skipped, 13 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖····✖··✖[0K
 [0K
  58 tests, 4 skipped, 13 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖·[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖····✖··✖·[0K
 [0K
  58 tests, 4 skipped, 13 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖··[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖····✖··✖··[0K
 [0K
  58 tests, 4 skipped, 13 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖···[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖····✖··✖···[0K
 [0K
  58 tests, 4 skipped, 13 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖····[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖····✖··✖····[0K
 [0K
  58 tests, 4 skipped, 13 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖·····[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖····✖··✖·····[0K
 [0K
  58 tests, 4 skipped, 13 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖······[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖····✖··✖······[0K
 [0K
  58 tests, 4 skipped, 13 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖·······[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖····✖··✖·······[0K
 [0K
  58 tests, 4 skipped, 13 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖········[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖····✖··✖········[0K
 [0K
  58 tests, 4 skipped, 13 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖·········[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖····✖··✖·········[0K
 [0K
  58 tests, 4 skipped, 13 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖·········[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖····✖··✖·········[0K
 [0K
  59 tests, 4 skipped, 13 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖·········↷[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖····✖··✖·········↷[0K
 [0K
  59 tests, 5 skipped, 13 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖·········↷[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖····✖··✖·········↷[0K
 [0K
  59 tests, 5 skipped, 13 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖·········↷·[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖····✖··✖·········↷·[0K
 [0K
  59 tests, 5 skipped, 13 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖·········↷·[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖····✖··✖·········↷·[0K
 [0K
  59 tests, 5 skipped, 13 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖·········↷··[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖····✖··✖·········↷··[0K
 [0K
  59 tests, 5 skipped, 13 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖·········↷··[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖····✖··✖·········↷··[0K
 [0K
  59 tests, 5 skipped, 13 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-       testjson/internal/withfails ···↷↷✖·✖····✖··✖·········↷···[0K
+[?25h[?25l[4A       testjson/internal/withfails ···↷↷✖·✖····✖··✖·········↷···[0K
 [0K
  59 tests, 5 skipped, 13 failures, 1 error
-[0K[?25h[?25l[9A[0K
 [0K
-   1ms testjson/internal/badmain [0K
-    🖴  testjson/internal/empty [0K
-    🖴  testjson/internal/good ···↷↷·············[0K
-  20ms testjson/internal/parallelfails ····✖✖✖✖✖✖✖✖[0K
-  20ms testjson/internal/withfails ···↷↷✖·✖····✖··✖·········↷···[0K
+[?25h[?25l[4A  20ms testjson/internal/withfails ···↷↷✖·✖····✖··✖·········↷···[0K
 [0K
  59 tests, 5 skipped, 13 failures, 1 error
-[0K[?25h
+[0K
+[?25h


### PR DESCRIPTION
This had some previous fixes:
* https://github.com/gotestyourself/gotestsum/pull/368
* https://github.com/gotestyourself/gotestsum/pull/354

These do not fully fix the problem, only mask the issues.

The real issues arise when there are 100s of packages to display, but only so much screen space. As each one bounces around, the text is entirely unreadable. The previous approaches was to more effieciently update the lines to make it more incremental.

The approach here is different - simple but extremely effective. Instead of trying to constantly write out the entire set of lines/packages under test, on each event, we keep track of a active and completed set of packages.

Once a package is completed, we write it out one last time, and then never overwrite it. The active set is treated as we do today.

This means if we have 8 core machine and 1000 packages, we are only updating 8 lines at a time, which removes all jitteriness.

The current PR totally breaks windows. If there is desire to move forward I can try to get it working on windows, but I don't have a windows machine so its a struggle for me