### PR TITLE
Skip test that is falky on macos

### DIFF
--- a/testjson/dotformat_test.go
+++ b/testjson/dotformat_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestScanTestOutput_WithDotsFormatter(t *testing.T) {
-	skip.If(t, runtime.GOOS == "windows")
+	skip.If(t, runtime.GOOS == "windows" || runtime.GOOS == "darwin")
 
 	out := new(bytes.Buffer)
 	dotfmt := &dotFormatter{


### PR DESCRIPTION
Seems reliable on linux, but recent PRs have had failures on macos runners.