### PR TITLE
Fix incorrect minVersion check - Bug here is either the function is misnamed or the logic is inverted

### DIFF
--- a/cmd/goversion_go122.go
+++ b/cmd/goversion_go122.go
@@ -9,5 +9,5 @@ import (
 )
 
 func isGoVersionAtLeast(v string) bool {
-	return goversion.Compare(runtime.Version(), v) < 0
+	return goversion.Compare(v, runtime.Version()) < 0
 }


### PR DESCRIPTION
This reads to me that the current running version is at least equal to the provided version in variable 'v'. In it's current form isGoVersionAtLeast will return false when go runtime is go1.23.0 and supplied string is go1.22 (which is what is being tested for now). 

I swapped the x,y to match the function name intent. I couldn't find any notes in diff if we wanted to explicitly not support 1.23 and later.

`func isGoVersionAtLeast(v string) bool {
	return goversion.Compare(v, runtime.Version()) < 0
}
`
