### PR TITLE
tolerate `run` without `pass/failed` for benchmarks

### DIFF
--- a/testjson/execution.go
+++ b/testjson/execution.go
@@ -213,6 +213,11 @@ func (n TestName) IsSubTest() bool {
 	return strings.Contains(string(n), "/")
 }
 
+// IsBenchmark returns true if the name indicates that the test is a benchmark.
+func (n TestName) IsBenchmark() bool {
+	return strings.HasPrefix(string(n), "Bench")
+}
+
 func (n TestName) Name() string {
 	return string(n)
 }
@@ -273,6 +278,13 @@ func (p *Package) end() []TestEvent {
 		if tc.Test.IsSubTest() && rootTestPassed(p, tc) {
 			// mitigate github.com/golang/go/issues/40771 (gotestsum/issues/141)
 			// by skipping missing subtest end events when the root test passed.
+			continue
+		}
+
+		if tc.Test.IsBenchmark() && !p.panicked {
+			// Mitigate go >= 1.20 issuing `run` events for benchmarks without
+			// a matching `pass` or `fail` event (https://github.com/gotestyourself/gotestsum/issues/413#issuecomment-2343206787,
+			// https://github.com/golang/go/issues/66825#issuecomment-2343229005).
 			continue
 		}
 

--- a/testjson/summary_test.go
+++ b/testjson/summary_test.go
@@ -305,6 +305,16 @@ func TestPrintSummary(t *testing.T) {
 			},
 			expectedOut: "summary/with-run-id",
 		},
+		{
+			name:        "Go 1.20 benchmark",
+			config:      scanConfigFromGolden("input/go-1-20-benchmark.out"),
+			expectedOut: "summary/go-1-20-benchmark",
+		},
+		{
+			name:        "Go 1.20 benchmark panic",
+			config:      scanConfigFromGolden("input/go-1-20-panicked-benchmark.out"),
+			expectedOut: "summary/go-1-20-benchmark-panic",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/testjson/testdata/input/go-1-20-benchmark.out
+++ b/testjson/testdata/input/go-1-20-benchmark.out
@@ -1,0 +1,12 @@
+{"Time":"2024-09-11T12:03:43.407422644+02:00","Action":"start","Package":"github.com/go-logr/logr/benchmark"}
+{"Time":"2024-09-11T12:03:43.412315359+02:00","Action":"output","Package":"github.com/go-logr/logr/benchmark","Output":"goos: linux\n"}
+{"Time":"2024-09-11T12:03:43.41235901+02:00","Action":"output","Package":"github.com/go-logr/logr/benchmark","Output":"goarch: amd64\n"}
+{"Time":"2024-09-11T12:03:43.412368425+02:00","Action":"output","Package":"github.com/go-logr/logr/benchmark","Output":"pkg: github.com/go-logr/logr/benchmark\n"}
+{"Time":"2024-09-11T12:03:43.412375551+02:00","Action":"output","Package":"github.com/go-logr/logr/benchmark","Output":"cpu: Intel(R) Core(TM) i9-7980XE CPU @ 2.60GHz\n"}
+{"Time":"2024-09-11T12:03:43.412385223+02:00","Action":"run","Package":"github.com/go-logr/logr/benchmark","Test":"BenchmarkDiscardLogInfoOneArg"}
+{"Time":"2024-09-11T12:03:43.412392388+02:00","Action":"output","Package":"github.com/go-logr/logr/benchmark","Test":"BenchmarkDiscardLogInfoOneArg","Output":"=== RUN   BenchmarkDiscardLogInfoOneArg\n"}
+{"Time":"2024-09-11T12:03:43.412399638+02:00","Action":"output","Package":"github.com/go-logr/logr/benchmark","Test":"BenchmarkDiscardLogInfoOneArg","Output":"BenchmarkDiscardLogInfoOneArg\n"}
+{"Time":"2024-09-11T12:03:44.671541518+02:00","Action":"output","Package":"github.com/go-logr/logr/benchmark","Test":"BenchmarkDiscardLogInfoOneArg","Output":"BenchmarkDiscardLogInfoOneArg-36    \t12695464\t        91.33 ns/op\n"}
+{"Time":"2024-09-11T12:03:44.671596547+02:00","Action":"output","Package":"github.com/go-logr/logr/benchmark","Output":"PASS\n"}
+{"Time":"2024-09-11T12:03:44.672577312+02:00","Action":"output","Package":"github.com/go-logr/logr/benchmark","Output":"ok  \tgithub.com/go-logr/logr/benchmark\t1.265s\n"}
+{"Time":"2024-09-11T12:03:44.67260672+02:00","Action":"pass","Package":"github.com/go-logr/logr/benchmark","Elapsed":1.2650000000000001}

--- a/testjson/testdata/input/go-1-20-panicked-benchmark.out
+++ b/testjson/testdata/input/go-1-20-panicked-benchmark.out
@@ -1,0 +1,12 @@
+{"Time":"2024-09-11T12:03:43.407422644+02:00","Action":"start","Package":"github.com/go-logr/logr/benchmark"}
+{"Time":"2024-09-11T12:03:43.412315359+02:00","Action":"output","Package":"github.com/go-logr/logr/benchmark","Output":"goos: linux\n"}
+{"Time":"2024-09-11T12:03:43.41235901+02:00","Action":"output","Package":"github.com/go-logr/logr/benchmark","Output":"goarch: amd64\n"}
+{"Time":"2024-09-11T12:03:43.412368425+02:00","Action":"output","Package":"github.com/go-logr/logr/benchmark","Output":"pkg: github.com/go-logr/logr/benchmark\n"}
+{"Time":"2024-09-11T12:03:43.412375551+02:00","Action":"output","Package":"github.com/go-logr/logr/benchmark","Output":"cpu: Intel(R) Core(TM) i9-7980XE CPU @ 2.60GHz\n"}
+{"Time":"2024-09-11T12:03:43.412385223+02:00","Action":"run","Package":"github.com/go-logr/logr/benchmark","Test":"BenchmarkDiscardLogInfoOneArg"}
+{"Time":"2024-09-11T12:03:43.412392388+02:00","Action":"output","Package":"github.com/go-logr/logr/benchmark","Test":"BenchmarkDiscardLogInfoOneArg","Output":"=== RUN   BenchmarkDiscardLogInfoOneArg\n"}
+{"Time":"2024-09-11T12:03:43.412399638+02:00","Action":"output","Package":"github.com/go-logr/logr/benchmark","Test":"BenchmarkDiscardLogInfoOneArg","Output":"BenchmarkDiscardLogInfoOneArg\n"}
+{"Time":"2024-09-11T12:03:44.671541518+02:00","Action":"output","Package":"github.com/go-logr/logr/benchmark","Test":"BenchmarkDiscardLogInfoOneArg","Output":"BenchmarkDiscardLogInfoOneArg-36    \t12695464\t        91.33 ns/op\n"}
+{"Time":"2024-09-11T12:03:44.671596547+02:00","Action":"output","Package":"github.com/go-logr/logr/benchmark","Output":"PASS\n"}
+{"Time":"2024-09-11T12:03:44.672577312+02:00","Action":"output","Package":"github.com/go-logr/logr/benchmark","Output":"ok  \tgithub.com/go-logr/logr/benchmark\t1.265s\n"}
+{"Time":"2024-09-11T12:03:44.67260672+02:00","Action":"output","Package":"github.com/go-logr/logr/benchmark","Output":"panic: fabricated panic"}

--- a/testjson/testdata/summary/go-1-20-benchmark
+++ b/testjson/testdata/summary/go-1-20-benchmark
@@ -1,0 +1,2 @@
+
+DONE 1 tests in 0.000s

--- a/testjson/testdata/summary/go-1-20-benchmark-panic
+++ b/testjson/testdata/summary/go-1-20-benchmark-panic
@@ -1,0 +1,8 @@
+
+=== Failed
+=== FAIL: github.com/go-logr/logr/benchmark BenchmarkDiscardLogInfoOneArg (unknown)
+=== RUN   BenchmarkDiscardLogInfoOneArg
+BenchmarkDiscardLogInfoOneArg
+BenchmarkDiscardLogInfoOneArg-36    	12695464	        91.33 ns/op
+
+DONE 1 tests, 1 failure in 0.000s


### PR DESCRIPTION
Something in Go 1.20 changed so that there is a `run` event for benchmarks. As before, there is no `pass` or `failed`. This triggers the "test is running and thus must have failed" logic in gotestsum, which causes it to report the benchmark as failed.

As this is the behavior of Go (whether it's correct or not...), gotestsum should accept such output. To reduce the risk that genuine problems go undetected, such incomplete benchmarks get reported when a panic was detected (the original motivation for this workaround).