### PR TITLE
fix(validate): fixes check for test.failfast flag as this is a gotest…

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -208,8 +208,8 @@ func (o options) Validate() error {
 			"when go test args are used with --rerun-fails " +
 				"the list of packages to test must be specified by the --packages flag")
 	}
-	if o.rerunFailsMaxAttempts > 0 && boolArgIndex("failfast", o.args) > -1 {
-		return fmt.Errorf("-failfast can not be used with --rerun-fails " +
+	if o.rerunFailsMaxAttempts > 0 && boolArgIndex("test.failfast", o.args) > -1 {
+		return fmt.Errorf("-test.failfast can not be used with --rerun-fails " +
 			"because not all test cases will run")
 	}
 	return nil

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -208,8 +208,10 @@ func (o options) Validate() error {
 			"when go test args are used with --rerun-fails " +
 				"the list of packages to test must be specified by the --packages flag")
 	}
-	if o.rerunFailsMaxAttempts > 0 && boolArgIndex("test.failfast", o.args) > -1 {
-		return fmt.Errorf("-test.failfast can not be used with --rerun-fails " +
+	if o.rerunFailsMaxAttempts > 0 &&
+		(boolArgIndex("failfast", o.args) > -1 ||
+			boolArgIndex("test.failfast", o.args) > -1) {
+		return fmt.Errorf("-(test.)failfast can not be used with --rerun-fails " +
 			"because not all test cases will run")
 	}
 	return nil

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -85,8 +85,8 @@ func TestOptions_Validate_FromFlags(t *testing.T) {
 		},
 		{
 			name:     "rerun-fails with failfast",
-			args:     []string{"--rerun-fails", "--packages=./...", "--", "-failfast"},
-			expected: "-failfast can not be used with --rerun-fails",
+			args:     []string{"--rerun-fails", "--packages=./...", "--", "-test.failfast"},
+			expected: "-test.failfast can not be used with --rerun-fails",
 		},
 	}
 	for _, tc := range testCases {

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -85,8 +85,13 @@ func TestOptions_Validate_FromFlags(t *testing.T) {
 		},
 		{
 			name:     "rerun-fails with failfast",
+			args:     []string{"--rerun-fails", "--packages=./...", "--", "-failfast"},
+			expected: "-(test.)failfast can not be used with --rerun-fails",
+		},
+		{
+			name:     "rerun-fails with failfast",
 			args:     []string{"--rerun-fails", "--packages=./...", "--", "-test.failfast"},
-			expected: "-test.failfast can not be used with --rerun-fails",
+			expected: "-(test.)failfast can not be used with --rerun-fails",
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
Our pipeline would sometimes pass without checking all tests as we had reruns and fail fast enabled.