### PR TITLE
Clean up nolint directives

### DIFF
--- a/.project/golangci-lint.yml
+++ b/.project/golangci-lint.yml
@@ -37,6 +37,7 @@ linters:
     - lll
     - misspell
     - nakedret
+    - nolintlint
     - prealloc
     - revive
     - staticcheck

--- a/cmd/handler.go
+++ b/cmd/handler.go
@@ -26,7 +26,7 @@ type writeSyncer interface {
 	Sync() error
 }
 
-// nolint:errcheck
+//nolint:errcheck
 func (h *eventHandler) Err(text string) error {
 	h.err.WriteString(text)
 	h.err.WriteRune('\n')

--- a/cmd/handler_test.go
+++ b/cmd/handler_test.go
@@ -53,7 +53,7 @@ func newExecFromTestData(t *testing.T) *testjson.Execution {
 	t.Helper()
 	f, err := os.Open("../testjson/testdata/input/go-test-json.out")
 	assert.NilError(t, err)
-	defer f.Close() // nolint: errcheck
+	defer f.Close() //nolint:errcheck
 
 	exec, err := testjson.ScanTestOutput(testjson.ScanConfig{
 		Stdout: f,

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -275,7 +275,7 @@ func run(opts *options) error {
 	if err != nil {
 		return err
 	}
-	defer handler.Close() // nolint: errcheck
+	defer handler.Close() //nolint:errcheck
 	cfg := testjson.ScanConfig{
 		Stdout:                   goTestProc.stdout,
 		Stderr:                   goTestProc.stderr,

--- a/cmd/main_e2e_test.go
+++ b/cmd/main_e2e_test.go
@@ -152,7 +152,7 @@ func (p *pkgFixtureFile) Do(f func() string) {
 	p.once.Do(func() {
 		p.filename = f()
 		p.cleanup = func() {
-			os.RemoveAll(p.filename) // nolint: errcheck
+			os.RemoveAll(p.filename) //nolint:errcheck
 		}
 	})
 }

--- a/cmd/rerunfails.go
+++ b/cmd/rerunfails.go
@@ -59,7 +59,7 @@ func rerunFailed(ctx context.Context, opts *options, scanConfig testjson.ScanCon
 	rec := newFailureRecorderFromExecution(scanConfig.Execution)
 	for attempts := 0; rec.count() > 0 && attempts < opts.rerunFailsMaxAttempts; attempts++ {
 		testjson.PrintSummary(opts.stdout, scanConfig.Execution, testjson.SummarizeNone)
-		opts.stdout.Write([]byte("\n")) // nolint: errcheck
+		opts.stdout.Write([]byte("\n")) //nolint:errcheck
 
 		nextRec := newFailureRecorder(scanConfig.Handler)
 		for _, tc := range tcFilter(rec.failures) {

--- a/cmd/tool/matrix/matrix_test.go
+++ b/cmd/tool/matrix/matrix_test.go
@@ -222,7 +222,6 @@ func TestRun(t *testing.T) {
 }
 
 // expectedMatrix can be automatically updated by running tests with -update
-// nolint:lll
 var expectedMatrix = `{
   "include": [
     {

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -79,7 +79,7 @@ func runSingle(opts *options, dir string) (*testjson.Execution, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer handler.Close() // nolint: errcheck
+	defer handler.Close() //nolint:errcheck
 	cfg := testjson.ScanConfig{
 		Stdout:  goTestProc.stdout,
 		Stderr:  goTestProc.stderr,
@@ -101,7 +101,7 @@ func delveInitFile(exec *testjson.Execution) (string, func(), error) {
 		return "", nil, err
 	}
 	remove := func() {
-		os.Remove(fh.Name()) // nolint: errcheck
+		os.Remove(fh.Name()) //nolint:errcheck
 	}
 
 	buf := bufio.NewWriter(fh)

--- a/internal/aggregate/slowest.go
+++ b/internal/aggregate/slowest.go
@@ -48,7 +48,6 @@ func ByElapsed(cases []testjson.TestCase, fn func(times []time.Duration) time.Du
 		return cases
 	}
 	pkg := cases[0].Package
-	// nolint: prealloc // size is not predictable
 	m := make(map[testjson.TestName][]time.Duration)
 	for _, tc := range cases {
 		m[tc.Test] = append(m[tc.Test], tc.Elapsed)

--- a/internal/filewatcher/watch.go
+++ b/internal/filewatcher/watch.go
@@ -36,13 +36,14 @@ type Event struct {
 }
 
 // Watch dirs for filesystem events, and run tests when .go files are saved.
-// nolint: gocyclo
+//
+//nolint:gocyclo
 func Watch(ctx context.Context, dirs []string, run func(Event) error) error {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		return fmt.Errorf("failed to create file watcher: %w", err)
 	}
-	defer watcher.Close() // nolint: errcheck // always returns nil error
+	defer watcher.Close() //nolint:errcheck // always returns nil error
 
 	if err := loadPaths(watcher, dirs); err != nil {
 		return err
@@ -110,7 +111,7 @@ func resetTimer(timer *time.Timer) {
 
 func loadPaths(watcher *fsnotify.Watcher, dirs []string) error {
 	toWatch := findAllDirs(dirs, maxDepth)
-	fmt.Printf("Watching %v directories. Use Ctrl-c to to stop a run or exit.\n", len(toWatch))
+	fmt.Printf("Watching %v directories. Use Ctrl-c to stop a run or exit.\n", len(toWatch))
 	for _, dir := range toWatch {
 		if err := watcher.Add(dir); err != nil {
 			return fmt.Errorf("failed to watch directory %v: %w", dir, err)
@@ -124,7 +125,7 @@ func findAllDirs(dirs []string, maxDepth int) []string {
 		dirs = []string{"./..."}
 	}
 
-	var output []string // nolint: prealloc
+	var output []string //nolint:prealloc
 	for _, dir := range dirs {
 		const recur = "/..."
 		if strings.HasSuffix(dir, recur) {
@@ -160,7 +161,7 @@ func findSubDirs(rootDir string, maxDepth int) []string {
 		output = append(output, path)
 		return nil
 	}
-	// nolint: errcheck // error is handled by walker func
+	//nolint:errcheck // error is handled by walker func
 	filepath.Walk(rootDir, walker)
 	return output
 }
@@ -186,7 +187,7 @@ func hasGoFiles(path string) bool {
 	if err != nil {
 		return false
 	}
-	defer fh.Close() // nolint: errcheck // fh is opened read-only
+	defer fh.Close() //nolint:errcheck // fh is opened read-only
 
 	for {
 		names, err := fh.Readdirnames(20)

--- a/testjson/dotformat.go
+++ b/testjson/dotformat.go
@@ -16,7 +16,6 @@ import (
 
 func dotsFormatV1(out io.Writer) EventFormatter {
 	buf := bufio.NewWriter(out)
-	// nolint:errcheck
 	return eventFormatterFunc(func(event TestEvent, exec *Execution) error {
 		pkg := exec.Package(event.Package)
 		switch {

--- a/testjson/execution.go
+++ b/testjson/execution.go
@@ -19,7 +19,6 @@ import (
 // Action of TestEvent
 type Action string
 
-// nolint: unused
 const (
 	ActionRun    Action = "run"
 	ActionPause  Action = "pause"
@@ -530,7 +529,7 @@ func (e *Execution) Failed() []TestCase {
 	if e == nil {
 		return nil
 	}
-	var failed []TestCase //nolint:prealloc
+	var failed []TestCase
 	for _, name := range sortedKeys(e.packages) {
 		pkg := e.packages[name]
 
@@ -641,7 +640,7 @@ func (e *Execution) HasPanic() bool {
 
 func (e *Execution) end() []TestEvent {
 	e.done = true
-	var result []TestEvent // nolint: prealloc
+	var result []TestEvent
 	for _, pkg := range e.packages {
 		result = append(result, pkg.end()...)
 	}
@@ -749,12 +748,12 @@ func readStdout(config ScanConfig, execution *Execution) error {
 		event, err := parseEvent(raw)
 		switch {
 		case err == errBadEvent:
-			// nolint: errcheck
+			//nolint:errcheck
 			config.Handler.Err(errBadEvent.Error() + ": " + scanner.Text())
 			continue
 		case err != nil:
 			if config.IgnoreNonJSONOutputLines {
-				// nolint: errcheck
+				//nolint:errcheck
 				config.Handler.Err(string(raw))
 				continue
 			}

--- a/testjson/execution_test.go
+++ b/testjson/execution_test.go
@@ -77,7 +77,7 @@ func (s *handlerFails) Err(_ string) error {
 }
 
 func TestParseEvent(t *testing.T) {
-	// nolint: lll
+	//nolint:lll
 	raw := `{"Time":"2018-03-22T22:33:35.168308334Z","Action":"output","Package":"example.com/good","Test": "TestOk","Output":"PASS\n"}`
 	event, err := parseEvent([]byte(raw))
 	assert.NilError(t, err)

--- a/testjson/format.go
+++ b/testjson/format.go
@@ -68,7 +68,7 @@ func standardQuietFormat(out io.Writer) EventFormatter {
 // go test -json
 func standardJSONFormat(out io.Writer) EventFormatter {
 	buf := bufio.NewWriter(out)
-	// nolint:errcheck // errors are returned by Flush
+	//nolint:errcheck // errors are returned by Flush
 	return eventFormatterFunc(func(event TestEvent, _ *Execution) error {
 		buf.Write(event.raw)
 		buf.WriteRune('\n')
@@ -140,7 +140,7 @@ func isFuzzCase(event TestEvent) bool {
 
 func testNameFormat(out io.Writer) EventFormatter {
 	buf := bufio.NewWriter(out)
-	// nolint:errcheck
+	//nolint:errcheck
 	return eventFormatterFunc(func(event TestEvent, exec *Execution) error {
 		formatTest := func() error {
 			testNameFormatTestEvent(buf, event)
@@ -379,12 +379,12 @@ func pkgNameWithFailuresFormat(out io.Writer, opts FormatOptions) eventFormatter
 			if event.Action == ActionFail {
 				pkg := exec.Package(event.Package)
 				tc := pkg.LastFailedByName(event.Test)
-				pkg.WriteOutputTo(buf, tc.ID) // nolint:errcheck
+				pkg.WriteOutputTo(buf, tc.ID) //nolint:errcheck
 				return buf.Flush()
 			}
 			return nil
 		}
-		buf.WriteString(shortFormatPackageEvent(opts, event, exec)) // nolint:errcheck
+		buf.WriteString(shortFormatPackageEvent(opts, event, exec))
 		return buf.Flush()
 	}
 }

--- a/testjson/summary.go
+++ b/testjson/summary.go
@@ -14,7 +14,6 @@ import (
 // Summary enumerates the sections which can be printed by PrintSummary
 type Summary int
 
-// nolint: golint
 const (
 	SummarizeNone    Summary = 0
 	SummarizeSkipped Summary = (1 << iota) / 2


### PR DESCRIPTION
The PR removes unused `//nolint` directives found with [`nolintlint`](https://golangci-lint.run/usage/linters/#nolintlint). Also, remove spaces between `nolint` and the linter name as `nolintlint` suggests.