### PR TITLE
Include build output from Go 1.24

### DIFF
--- a/testjson/dotformat.go
+++ b/testjson/dotformat.go
@@ -100,7 +100,7 @@ func (d *dotFormatter) Format(event TestEvent, exec *Execution) error {
 		line.update(fmtDot(event))
 	}
 	switch event.Action {
-	case ActionOutput, ActionBench:
+	case ActionOutput, ActionBuild, ActionBench:
 		return nil
 	}
 

--- a/testjson/execution_test.go
+++ b/testjson/execution_test.go
@@ -104,7 +104,7 @@ func TestPackage_AddEvent(t *testing.T) {
 		te, err := parseEvent([]byte(tc.event))
 		assert.NilError(t, err)
 
-		p := newPackage()
+		p := newPackage(nil)
 		p.addEvent(te)
 		assert.DeepEqual(t, p, &tc.expected, cmpPackage)
 	}

--- a/testjson/format.go
+++ b/testjson/format.go
@@ -29,7 +29,7 @@ func debugFormat(out io.Writer) eventFormatterFunc {
 func standardVerboseFormat(out io.Writer) EventFormatter {
 	buf := bufio.NewWriter(out)
 	return eventFormatterFunc(func(event TestEvent, _ *Execution) error {
-		if event.Action == ActionOutput {
+		if event.Action == ActionOutput || event.Action == ActionBuild {
 			_, _ = buf.WriteString(event.Output)
 			return buf.Flush()
 		}
@@ -467,7 +467,7 @@ func githubActionsFormat(out io.Writer) EventFormatter {
 		key := name{Package: event.Package, Test: event.Test}
 
 		// test case output
-		if event.Test != "" && event.Action == ActionOutput {
+		if event.Test != "" && (event.Action == ActionOutput || event.Action == ActionBuild) {
 			if !isFramingLine(event.Output, event.Test) {
 				output[key] = append(output[key], event.Output)
 			}


### PR DESCRIPTION
Go 1.24 now has the build errors and such in the json rather than on stderr. This makes sure that those messages show up.