### PR TITLE
Fix: gotestsum swallows build errors

### DIFF
--- a/cmd/handler_test.go
+++ b/cmd/handler_test.go
@@ -174,3 +174,49 @@ func TestScanTestOutput_TestTimeoutPanicRace(t *testing.T) {
 		})
 	}
 }
+
+func TestEventHandler_TestBuildFail(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "no")
+	t.Setenv("NO_COLOR", "true")
+
+	buf := new(bufferCloser)
+	errBuf := new(bytes.Buffer)
+	format := testjson.NewEventFormatter(errBuf, "testname", testjson.FormatOptions{})
+
+	source := golden.Get(t, "input/go-test-build-failed.out")
+	cfg := testjson.ScanConfig{
+		Stdout:  bytes.NewReader(source),
+		Handler: &eventHandler{jsonFile: buf, formatter: format},
+	}
+	exec, err := testjson.ScanTestOutput(cfg)
+	assert.NilError(t, err)
+
+	out := new(bytes.Buffer)
+	testjson.PrintSummary(out, exec, testjson.SummarizeAll)
+
+	actual := text.ProcessLines(t, out, text.OpRemoveSummaryLineElapsedTime)
+	golden.Assert(t, actual, "expected/build-fail-expected")
+}
+
+func TestEventHandler_SetupFail(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "no")
+	t.Setenv("NO_COLOR", "true")
+
+	buf := new(bufferCloser)
+	errBuf := new(bytes.Buffer)
+	format := testjson.NewEventFormatter(errBuf, "testname", testjson.FormatOptions{})
+
+	source := golden.Get(t, "input/go-test-setup-failed.out")
+	cfg := testjson.ScanConfig{
+		Stdout:  bytes.NewReader(source),
+		Handler: &eventHandler{jsonFile: buf, formatter: format},
+	}
+	exec, err := testjson.ScanTestOutput(cfg)
+	assert.NilError(t, err)
+
+	out := new(bytes.Buffer)
+	testjson.PrintSummary(out, exec, testjson.SummarizeAll)
+
+	actual := text.ProcessLines(t, out, text.OpRemoveSummaryLineElapsedTime)
+	golden.Assert(t, actual, "expected/setup-fail-expected")
+}

--- a/cmd/handler_test.go
+++ b/cmd/handler_test.go
@@ -175,9 +175,10 @@ func TestScanTestOutput_TestTimeoutPanicRace(t *testing.T) {
 	}
 }
 
+// Tests output when a package fails to build because of a compilation error
+// and no tests are run in the package.
 func TestEventHandler_TestBuildFail(t *testing.T) {
 	t.Setenv("GITHUB_ACTIONS", "no")
-	t.Setenv("NO_COLOR", "true")
 
 	buf := new(bufferCloser)
 	errBuf := new(bytes.Buffer)
@@ -198,9 +199,10 @@ func TestEventHandler_TestBuildFail(t *testing.T) {
 	golden.Assert(t, actual, "expected/build-fail-expected")
 }
 
+// Tests output when a package fails to build because of a compilation error
+// due to syntax errors and the like.
 func TestEventHandler_SetupFail(t *testing.T) {
 	t.Setenv("GITHUB_ACTIONS", "no")
-	t.Setenv("NO_COLOR", "true")
 
 	buf := new(bufferCloser)
 	errBuf := new(bytes.Buffer)

--- a/cmd/testdata/expected/build-fail-expected
+++ b/cmd/testdata/expected/build-fail-expected
@@ -1,0 +1,8 @@
+
+=== Failed
+=== FAIL: example.com/internal/cacher  (0.00s)
+# example.com/internal/cacher [example.com/internal/cacher.test]
+./directory_test.go:321:10: undefined: assert.foo
+FAIL	example.com/internal/cacher [build failed]
+
+DONE 0 tests, 1 failure

--- a/cmd/testdata/expected/setup-fail-expected
+++ b/cmd/testdata/expected/setup-fail-expected
@@ -1,0 +1,13 @@
+
+=== Failed
+=== FAIL: example.com/internal/cacher  (0.00s)
+# example.com/internal/cacher
+directory_test.go:321:13: expected ';', found o
+FAIL	example.com/internal/cacher [setup failed]
+
+=== FAIL: example.com/internal/cacher/subpkg  (0.00s)
+# example.com/internal/cacher/subpkg
+subpkg/main_test.go:1:1: expected 'package', found aldfjadskfs
+FAIL	example.com/internal/cacher/subpkg [setup failed]
+
+DONE 0 tests, 2 failures

--- a/cmd/testdata/input/go-test-build-failed.out
+++ b/cmd/testdata/input/go-test-build-failed.out
@@ -1,0 +1,6 @@
+{"ImportPath":"example.com/internal/cacher [example.com/internal/cacher.test]","Action":"build-output","Output":"# example.com/internal/cacher [example.com/internal/cacher.test]\n"}
+{"ImportPath":"example.com/internal/cacher [example.com/internal/cacher.test]","Action":"build-output","Output":"./directory_test.go:321:10: undefined: assert.foo\n"}
+{"ImportPath":"example.com/internal/cacher [example.com/internal/cacher.test]","Action":"build-fail"}
+{"Time":"2025-03-10T17:34:31.493978-07:00","Action":"start","Package":"example.com/internal/cacher"}
+{"Time":"2025-03-10T17:34:31.494027-07:00","Action":"output","Package":"example.com/internal/cacher","Output":"FAIL\texample.com/internal/cacher [build failed]\n"}
+{"Time":"2025-03-10T17:34:31.494039-07:00","Action":"fail","Package":"example.com/internal/cacher","Elapsed":0,"FailedBuild":"example.com/internal/cacher [example.com/internal/cacher.test]"}

--- a/cmd/testdata/input/go-test-setup-failed.out
+++ b/cmd/testdata/input/go-test-setup-failed.out
@@ -1,0 +1,12 @@
+{"ImportPath":"example.com/internal/cacher.test","Action":"build-output","Output":"# example.com/internal/cacher\n"}
+{"ImportPath":"example.com/internal/cacher.test","Action":"build-output","Output":"directory_test.go:321:13: expected ';', found o\n"}
+{"ImportPath":"example.com/internal/cacher.test","Action":"build-fail"}
+{"Time":"2025-03-11T10:08:34.978868-07:00","Action":"start","Package":"example.com/internal/cacher"}
+{"Time":"2025-03-11T10:08:34.978905-07:00","Action":"output","Package":"example.com/internal/cacher","Output":"FAIL\texample.com/internal/cacher [setup failed]\n"}
+{"Time":"2025-03-11T10:08:34.978914-07:00","Action":"fail","Package":"example.com/internal/cacher","Elapsed":0,"FailedBuild":"example.com/internal/cacher.test"}
+{"ImportPath":"example.com/internal/cacher/subpkg","Action":"build-output","Output":"# example.com/internal/cacher/subpkg\n"}
+{"ImportPath":"example.com/internal/cacher/subpkg","Action":"build-output","Output":"subpkg/main_test.go:1:1: expected 'package', found aldfjadskfs\n"}
+{"ImportPath":"example.com/internal/cacher/subpkg","Action":"build-fail"}
+{"Time":"2025-03-11T10:08:34.978928-07:00","Action":"start","Package":"example.com/internal/cacher/subpkg"}
+{"Time":"2025-03-11T10:08:34.979019-07:00","Action":"output","Package":"example.com/internal/cacher/subpkg","Output":"FAIL\texample.com/internal/cacher/subpkg [setup failed]\n"}
+{"Time":"2025-03-11T10:08:34.979028-07:00","Action":"fail","Package":"example.com/internal/cacher/subpkg","Elapsed":0,"FailedBuild":"example.com/internal/cacher/subpkg"}

--- a/testjson/format.go
+++ b/testjson/format.go
@@ -29,7 +29,7 @@ func debugFormat(out io.Writer) eventFormatterFunc {
 func standardVerboseFormat(out io.Writer) EventFormatter {
 	buf := bufio.NewWriter(out)
 	return eventFormatterFunc(func(event TestEvent, _ *Execution) error {
-		if event.Action == ActionOutput || event.Action == ActionBuildOutput {
+		if event.Action == ActionOutput {
 			_, _ = buf.WriteString(event.Output)
 			return buf.Flush()
 		}

--- a/testjson/format.go
+++ b/testjson/format.go
@@ -29,7 +29,7 @@ func debugFormat(out io.Writer) eventFormatterFunc {
 func standardVerboseFormat(out io.Writer) EventFormatter {
 	buf := bufio.NewWriter(out)
 	return eventFormatterFunc(func(event TestEvent, _ *Execution) error {
-		if event.Action == ActionOutput {
+		if event.Action == ActionOutput || event.Action == ActionBuildOutput {
 			_, _ = buf.WriteString(event.Output)
 			return buf.Flush()
 		}


### PR DESCRIPTION
When we run `go test` when there are build failures, we get the following error
```
# example.com/internal/cacher [example.com/internal/cacher.test]
./directory_test.go:321:10: undefined: assert.foo
FAIL    example/internal/cacher [build failed]
FAIL
```

However, when ran with `gotestsum`, we get
```
✖  internal/cacher

=== Failed
=== FAIL: internal/cacher  (0.00s)
FAIL    example.com/internal/cacher [setup failed]

DONE 0 tests, 1 failure in 0.074s
```

Notice that we lost these two lines, which contains meaningful information for debugging
```
# example.com/internal/cacher
directory_test.go:321:10: undefined: assert.foo
```

This is because `go test -json` emits build errors in special events with `"Action":"build-output"` and `"Action":"build-fail"`, but these event types are not handled by `gotestsum`. 

```

{"ImportPath":"example.com/internal/cacher [example.com/internal/cacher.test]","Action":"build-output","Output":"# example.com/internal/cacher [example.com/internal/cacher.test]\n"}
{"ImportPath":"example.com/internal/cacher [example.com/internal/cacher.test]","Action":"build-output","Output":"./directory_test.go:321:10: undefined: assert.foo\n"}
{"ImportPath":"example.com/internal/cacher [example.com/internal/cacher.test]","Action":"build-fail"}
{"Time":"2025-03-11T10:51:27.686438-07:00","Action":"start","Package":"example.com/internal/cacher"}
{"Time":"2025-03-11T10:51:27.686503-07:00","Action":"output","Package":"example.com/internal/cacher","Output":"FAIL\texample.com/internal/cacher [build failed]\n"}
{"Time":"2025-03-11T10:51:27.686509-07:00","Action":"fail","Package":"example.com/internal/cacher","Elapsed":0,"FailedBuild":"example.com/internal/cacher [example.com/internal/cacher.test]"}
```

Note that these events have an ImportPath for the package that failed to build.
The import path may be the direct import path, the import path of the test package (`example.com/foo.test`), or the combined import path (`example.com/foo [example.com/foo.test]`) based on how `go build` treats test packages.
[Related `go list` documentation](https://pkg.go.dev/cmd/go#:~:text=The%20%2Dtest%20flag,the%20previous%20examples).

This PR adds support to parse these events.

The output now looks like 
```
=== Failed
=== FAIL: example.com/internal/cacher  (0.00s)
# example.com/internal/cacher [example.com/internal/cacher.test]
./directory_test.go:321:10: undefined: assert.foo
FAIL	example.com/internal/cacher [build failed]

DONE 0 tests, 1 failure
```

The tests cases are generated by running `go test ./... -json` in a package with compilation errors and syntax errors.