### PR TITLE
Include new json build failures  (go1.24)

### DIFF
--- a/cmd/main_e2e_test.go
+++ b/cmd/main_e2e_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	goversion "go/version"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -123,17 +124,16 @@ func osEnviron() map[string]string {
 func expectedFilename(name string) string {
 	ver := runtime.Version()
 	switch {
-	case isPreGo120(ver):
-		return name + "-go1.19"
+	case isPreGo124(ver):
+		return name + "-go1.23"
 	default:
 		return name
 	}
 }
 
-// go1.20.0 changed how it prints messages from subtests. It seems the output
-// has changed back to match the output from go1.14 and earlier.
-func isPreGo120(ver string) bool {
-	return strings.HasPrefix(ver, "go1.1")
+// go1.24 changed how it handles build output
+func isPreGo124(ver string) bool {
+	return goversion.Compare(ver, "go1.24") < 0
 }
 
 var binaryFixture pkgFixtureFile

--- a/cmd/testdata/e2e/expected/TestE2E_RerunFails/first_run_has_errors,_abort_rerun-go1.19
+++ b/cmd/testdata/e2e/expected/TestE2E_RerunFails/first_run_has_errors,_abort_rerun-go1.19
@@ -1,5 +1,0 @@
-
-=== Errors
-../testjson/internal/broken/broken.go:5:21: undefined: somepackage
-
-DONE 0 tests, 1 error

--- a/cmd/testdata/e2e/expected/TestE2E_RerunFails/first_run_has_errors,_abort_rerun-go1.23
+++ b/cmd/testdata/e2e/expected/TestE2E_RerunFails/first_run_has_errors,_abort_rerun-go1.23
@@ -7,5 +7,4 @@ FAIL	gotest.tools/gotestsum/testjson/internal/broken [build failed]
 === Errors
 ../testjson/internal/broken/broken.go:5:21: undefined: somepackage
 
-
 DONE 0 tests, 1 failure, 1 error

--- a/cmd/testdata/e2e/expected/TestE2E_RerunFails/reruns_continues_to_fail-go1.23
+++ b/cmd/testdata/e2e/expected/TestE2E_RerunFails/reruns_continues_to_fail-go1.23
@@ -12,7 +12,7 @@ FAIL cmd/testdata/e2e/flaky.TestFailsSometimes
 PASS cmd/testdata/e2e/flaky.TestFailsOften/subtest_always_passes
 === RUN   TestFailsOften/subtest_may_fail
     flaky_test.go:68: not this time
-    --- FAIL: TestFailsOften/subtest_may_fail
+--- FAIL: TestFailsOften/subtest_may_fail
 FAIL cmd/testdata/e2e/flaky.TestFailsOften/subtest_may_fail
 === RUN   TestFailsOften
 SEED:  0
@@ -30,7 +30,7 @@ PASS cmd/testdata/e2e/flaky.TestFailsSometimes (re-run 1)
 PASS cmd/testdata/e2e/flaky
 === RUN   TestFailsOften/subtest_may_fail
     flaky_test.go:68: not this time
-    --- FAIL: TestFailsOften/subtest_may_fail
+--- FAIL: TestFailsOften/subtest_may_fail
 FAIL cmd/testdata/e2e/flaky.TestFailsOften/subtest_may_fail (re-run 1)
 === RUN   TestFailsOften
 SEED:  3
@@ -42,7 +42,7 @@ DONE 2 runs, 12 tests, 6 failures
 
 === RUN   TestFailsOften/subtest_may_fail
     flaky_test.go:68: not this time
-    --- FAIL: TestFailsOften/subtest_may_fail
+--- FAIL: TestFailsOften/subtest_may_fail
 FAIL cmd/testdata/e2e/flaky.TestFailsOften/subtest_may_fail (re-run 2)
 === RUN   TestFailsOften
 SEED:  4
@@ -61,21 +61,18 @@ SEED:  0
 
 === FAIL: cmd/testdata/e2e/flaky TestFailsOften/subtest_may_fail
     flaky_test.go:68: not this time
-    --- FAIL: TestFailsOften/subtest_may_fail
 
 === FAIL: cmd/testdata/e2e/flaky TestFailsOften
 SEED:  0
 
 === FAIL: cmd/testdata/e2e/flaky TestFailsOften/subtest_may_fail (re-run 1)
     flaky_test.go:68: not this time
-    --- FAIL: TestFailsOften/subtest_may_fail
 
 === FAIL: cmd/testdata/e2e/flaky TestFailsOften (re-run 1)
 SEED:  3
 
 === FAIL: cmd/testdata/e2e/flaky TestFailsOften/subtest_may_fail (re-run 2)
     flaky_test.go:68: not this time
-    --- FAIL: TestFailsOften/subtest_may_fail
 
 === FAIL: cmd/testdata/e2e/flaky TestFailsOften (re-run 2)
 SEED:  4

--- a/cmd/testdata/e2e/expected/TestE2E_RerunFails/reruns_until_success-go1.23
+++ b/cmd/testdata/e2e/expected/TestE2E_RerunFails/reruns_until_success-go1.23
@@ -12,7 +12,7 @@ FAIL cmd/testdata/e2e/flaky.TestFailsSometimes
 PASS cmd/testdata/e2e/flaky.TestFailsOften/subtest_always_passes
 === RUN   TestFailsOften/subtest_may_fail
     flaky_test.go:68: not this time
-    --- FAIL: TestFailsOften/subtest_may_fail
+--- FAIL: TestFailsOften/subtest_may_fail
 FAIL cmd/testdata/e2e/flaky.TestFailsOften/subtest_may_fail
 === RUN   TestFailsOften
 SEED:  0
@@ -30,7 +30,7 @@ PASS cmd/testdata/e2e/flaky.TestFailsSometimes (re-run 1)
 PASS cmd/testdata/e2e/flaky
 === RUN   TestFailsOften/subtest_may_fail
     flaky_test.go:68: not this time
-    --- FAIL: TestFailsOften/subtest_may_fail
+--- FAIL: TestFailsOften/subtest_may_fail
 FAIL cmd/testdata/e2e/flaky.TestFailsOften/subtest_may_fail (re-run 1)
 === RUN   TestFailsOften
 SEED:  3
@@ -42,7 +42,7 @@ DONE 2 runs, 12 tests, 6 failures
 
 === RUN   TestFailsOften/subtest_may_fail
     flaky_test.go:68: not this time
-    --- FAIL: TestFailsOften/subtest_may_fail
+--- FAIL: TestFailsOften/subtest_may_fail
 FAIL cmd/testdata/e2e/flaky.TestFailsOften/subtest_may_fail (re-run 2)
 === RUN   TestFailsOften
 SEED:  4
@@ -54,7 +54,7 @@ DONE 3 runs, 14 tests, 8 failures
 
 === RUN   TestFailsOften/subtest_may_fail
     flaky_test.go:68: not this time
-    --- FAIL: TestFailsOften/subtest_may_fail
+--- FAIL: TestFailsOften/subtest_may_fail
 FAIL cmd/testdata/e2e/flaky.TestFailsOften/subtest_may_fail (re-run 3)
 === RUN   TestFailsOften
 SEED:  5
@@ -79,28 +79,24 @@ SEED:  0
 
 === FAIL: cmd/testdata/e2e/flaky TestFailsOften/subtest_may_fail
     flaky_test.go:68: not this time
-    --- FAIL: TestFailsOften/subtest_may_fail
 
 === FAIL: cmd/testdata/e2e/flaky TestFailsOften
 SEED:  0
 
 === FAIL: cmd/testdata/e2e/flaky TestFailsOften/subtest_may_fail (re-run 1)
     flaky_test.go:68: not this time
-    --- FAIL: TestFailsOften/subtest_may_fail
 
 === FAIL: cmd/testdata/e2e/flaky TestFailsOften (re-run 1)
 SEED:  3
 
 === FAIL: cmd/testdata/e2e/flaky TestFailsOften/subtest_may_fail (re-run 2)
     flaky_test.go:68: not this time
-    --- FAIL: TestFailsOften/subtest_may_fail
 
 === FAIL: cmd/testdata/e2e/flaky TestFailsOften (re-run 2)
 SEED:  4
 
 === FAIL: cmd/testdata/e2e/flaky TestFailsOften/subtest_may_fail (re-run 3)
     flaky_test.go:68: not this time
-    --- FAIL: TestFailsOften/subtest_may_fail
 
 === FAIL: cmd/testdata/e2e/flaky TestFailsOften (re-run 3)
 SEED:  5

--- a/cmd/testdata/expected/build-fail-expected
+++ b/cmd/testdata/expected/build-fail-expected
@@ -1,0 +1,8 @@
+
+=== Failed
+=== FAIL: example.com/internal/cacher  (0.00s)
+# example.com/internal/cacher [example.com/internal/cacher.test]
+./directory_test.go:321:10: undefined: assert.foo
+FAIL	example.com/internal/cacher [build failed]
+
+DONE 0 tests, 1 failure

--- a/cmd/testdata/expected/build-fail-expected
+++ b/cmd/testdata/expected/build-fail-expected
@@ -1,8 +1,10 @@
 
 === Failed
 === FAIL: example.com/internal/cacher  (0.00s)
-# example.com/internal/cacher [example.com/internal/cacher.test]
-./directory_test.go:321:10: undefined: assert.foo
 FAIL	example.com/internal/cacher [build failed]
 
-DONE 0 tests, 1 failure
+=== Errors
+./directory_test.go:321:10: undefined: assert.foo
+
+
+DONE 0 tests, 1 failure, 1 error

--- a/cmd/testdata/expected/setup-fail-expected
+++ b/cmd/testdata/expected/setup-fail-expected
@@ -1,13 +1,15 @@
 
 === Failed
 === FAIL: example.com/internal/cacher  (0.00s)
-# example.com/internal/cacher
-directory_test.go:321:13: expected ';', found o
 FAIL	example.com/internal/cacher [setup failed]
 
 === FAIL: example.com/internal/cacher/subpkg  (0.00s)
-# example.com/internal/cacher/subpkg
-subpkg/main_test.go:1:1: expected 'package', found aldfjadskfs
 FAIL	example.com/internal/cacher/subpkg [setup failed]
 
-DONE 0 tests, 2 failures
+=== Errors
+directory_test.go:321:13: expected ';', found o
+
+subpkg/main_test.go:1:1: expected 'package', found aldfjadskfs
+
+
+DONE 0 tests, 2 failures, 2 errors

--- a/cmd/testdata/expected/setup-fail-expected
+++ b/cmd/testdata/expected/setup-fail-expected
@@ -1,0 +1,13 @@
+
+=== Failed
+=== FAIL: example.com/internal/cacher  (0.00s)
+# example.com/internal/cacher
+directory_test.go:321:13: expected ';', found o
+FAIL	example.com/internal/cacher [setup failed]
+
+=== FAIL: example.com/internal/cacher/subpkg  (0.00s)
+# example.com/internal/cacher/subpkg
+subpkg/main_test.go:1:1: expected 'package', found aldfjadskfs
+FAIL	example.com/internal/cacher/subpkg [setup failed]
+
+DONE 0 tests, 2 failures

--- a/cmd/testdata/input/go-test-build-failed.out
+++ b/cmd/testdata/input/go-test-build-failed.out
@@ -1,0 +1,6 @@
+{"ImportPath":"example.com/internal/cacher [example.com/internal/cacher.test]","Action":"build-output","Output":"# example.com/internal/cacher [example.com/internal/cacher.test]\n"}
+{"ImportPath":"example.com/internal/cacher [example.com/internal/cacher.test]","Action":"build-output","Output":"./directory_test.go:321:10: undefined: assert.foo\n"}
+{"ImportPath":"example.com/internal/cacher [example.com/internal/cacher.test]","Action":"build-fail"}
+{"Time":"2025-03-10T17:34:31.493978-07:00","Action":"start","Package":"example.com/internal/cacher"}
+{"Time":"2025-03-10T17:34:31.494027-07:00","Action":"output","Package":"example.com/internal/cacher","Output":"FAIL\texample.com/internal/cacher [build failed]\n"}
+{"Time":"2025-03-10T17:34:31.494039-07:00","Action":"fail","Package":"example.com/internal/cacher","Elapsed":0,"FailedBuild":"example.com/internal/cacher [example.com/internal/cacher.test]"}

--- a/cmd/testdata/input/go-test-setup-failed.out
+++ b/cmd/testdata/input/go-test-setup-failed.out
@@ -1,0 +1,12 @@
+{"ImportPath":"example.com/internal/cacher.test","Action":"build-output","Output":"# example.com/internal/cacher\n"}
+{"ImportPath":"example.com/internal/cacher.test","Action":"build-output","Output":"directory_test.go:321:13: expected ';', found o\n"}
+{"ImportPath":"example.com/internal/cacher.test","Action":"build-fail"}
+{"Time":"2025-03-11T10:08:34.978868-07:00","Action":"start","Package":"example.com/internal/cacher"}
+{"Time":"2025-03-11T10:08:34.978905-07:00","Action":"output","Package":"example.com/internal/cacher","Output":"FAIL\texample.com/internal/cacher [setup failed]\n"}
+{"Time":"2025-03-11T10:08:34.978914-07:00","Action":"fail","Package":"example.com/internal/cacher","Elapsed":0,"FailedBuild":"example.com/internal/cacher.test"}
+{"ImportPath":"example.com/internal/cacher/subpkg","Action":"build-output","Output":"# example.com/internal/cacher/subpkg\n"}
+{"ImportPath":"example.com/internal/cacher/subpkg","Action":"build-output","Output":"subpkg/main_test.go:1:1: expected 'package', found aldfjadskfs\n"}
+{"ImportPath":"example.com/internal/cacher/subpkg","Action":"build-fail"}
+{"Time":"2025-03-11T10:08:34.978928-07:00","Action":"start","Package":"example.com/internal/cacher/subpkg"}
+{"Time":"2025-03-11T10:08:34.979019-07:00","Action":"output","Package":"example.com/internal/cacher/subpkg","Output":"FAIL\texample.com/internal/cacher/subpkg [setup failed]\n"}
+{"Time":"2025-03-11T10:08:34.979028-07:00","Action":"fail","Package":"example.com/internal/cacher/subpkg","Elapsed":0,"FailedBuild":"example.com/internal/cacher/subpkg"}

--- a/testjson/execution.go
+++ b/testjson/execution.go
@@ -28,6 +28,7 @@ const (
 	ActionFail   Action = "fail"
 	ActionOutput Action = "output"
 	ActionSkip   Action = "skip"
+	ActionBuild  Action = "build-output"
 )
 
 // IsTerminal returns true if the Action is one of: pass, fail, skip.
@@ -43,10 +44,11 @@ func (a Action) IsTerminal() bool {
 // TestEvent is a structure output by go tool test2json and go test -json.
 type TestEvent struct {
 	// Time encoded as an RFC3339-format string
-	Time    time.Time
-	Action  Action
-	Package string
-	Test    string
+	Time       time.Time
+	Action     Action
+	Package    string
+	Test       string
+	ImportPath string
 	// Elapsed time in seconds
 	Elapsed float64
 	// Output of test or benchmark
@@ -357,6 +359,10 @@ func (e *Execution) add(event TestEvent) {
 	if !ok {
 		pkg = newPackage()
 		e.packages[event.Package] = pkg
+	}
+	if event.Action == ActionBuild {
+		e.addError(event.Output)
+		return
 	}
 	if event.PackageEvent() {
 		pkg.addEvent(event)


### PR DESCRIPTION
Closes #469
Related to #474

Build errors are no longer in stderr and are now part of the JSON.

This PR doesn't attempt to put the build errors into the package where they failed, it simply shows them under "=== Errors" as it did before.

I opened #475, because I guess it should now be possible to include the JSON errors in the junitxml under the package that caused them.