### PR TITLE
feat: Add flag to disable `GITHUB_ACTIONS` override

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ Commonly used formats (see `--help` for a full list):
 Have an idea for a new format?
 Please [share it on github](https://github.com/gotestyourself/gotestsum/issues/new)!
 
+> [!NOTE]
+> When running with the `testname` or `standard-verbose` format, if the `GITHUB_ACTIONS` environment variable is
+> set, the format will automatically be changed to `github-actions` by default. To prevent this, pass the
+> `--format-disable-gha` flag.
+
 #### Demo
 
 A demonstration of three `--format` options.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -64,6 +64,8 @@ func setupFlags(name string) (*pflag.FlagSet, *options) {
 		false, "do not print empty packages in compact formats")
 	flags.BoolVar(&opts.formatOptions.UseHiVisibilityIcons, "format-hivis",
 		false, "use high visibility characters in some formats")
+	flags.BoolVar(&opts.formatOptions.DisableGithubActionsFormat, "format-disable-gha",
+		false, "do not force-enable github actions format on 'testname' or 'short-verbose' formats")
 	_ = flags.MarkHidden("format-hivis")
 	flags.StringVar(&opts.formatOptions.Icons, "format-icons",
 		lookEnvWithDefault("GOTESTSUM_FORMAT_ICONS", ""),

--- a/cmd/testdata/gotestsum-help-text
+++ b/cmd/testdata/gotestsum-help-text
@@ -7,6 +7,7 @@ See https://pkg.go.dev/gotest.tools/gotestsum#section-readme for detailed docume
 Flags:
       --debug                                       enabled debug logging
   -f, --format string                               print format of test input (default "pkgname")
+      --format-disable-gha                          do not force-enable github actions format on 'testname' or 'short-verbose' formats
       --format-hide-empty-pkg                       do not print empty packages in compact formats
       --format-icons string                         use different icons, see help for options
       --hide-summary summary                        hide sections of the summary: skipped,failed,errors,output (default none)

--- a/testjson/format.go
+++ b/testjson/format.go
@@ -414,9 +414,10 @@ func (e eventFormatterFunc) Format(event TestEvent, output *Execution) error {
 }
 
 type FormatOptions struct {
-	HideEmptyPackages    bool
-	UseHiVisibilityIcons bool // Deprecated
-	Icons                string
+	HideEmptyPackages          bool
+	UseHiVisibilityIcons       bool // Deprecated
+	Icons                      string
+	DisableGithubActionsFormat bool
 }
 
 // NewEventFormatter returns a formatter for printing events.
@@ -439,7 +440,7 @@ func NewEventFormatter(out io.Writer, format string, formatOpts FormatOptions) E
 	case "gotestdox", "testdox":
 		return testDoxFormat(out, formatOpts)
 	case "testname", "short-verbose":
-		if os.Getenv("GITHUB_ACTIONS") == "true" {
+		if !formatOpts.DisableGithubActionsFormat && os.Getenv("GITHUB_ACTIONS") == "true" {
 			return githubActionsFormat(out)
 		}
 		return testNameFormat(out)

--- a/testjson/format_test.go
+++ b/testjson/format_test.go
@@ -3,6 +3,7 @@ package testjson
 import (
 	"bytes"
 	"io"
+	"os"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -99,6 +100,26 @@ func TestFormats_DefaultGoTestJson(t *testing.T) {
 			expectedOut: "format/testname.out",
 		},
 		{
+			name: "testname-with-enabled-gha",
+			format: func(out io.Writer) EventFormatter {
+				err := os.Setenv("GITHUB_ACTIONS", "true")
+				assert.NilError(t, err)
+				return NewEventFormatter(out, "testname", FormatOptions{})
+			},
+			expectedOut: "format/github-actions.out",
+		},
+		{
+			name: "testname-with-disabled-gha",
+			format: func(out io.Writer) EventFormatter {
+				err := os.Setenv("GITHUB_ACTIONS", "true")
+				assert.NilError(t, err)
+				return NewEventFormatter(out, "testname", FormatOptions{
+					DisableGithubActionsFormat: true,
+				})
+			},
+			expectedOut: "format/testname.out",
+		},
+		{
 			name:        "dots-v1",
 			format:      dotsFormatV1,
 			expectedOut: "format/dots-v1.out",
@@ -156,6 +177,26 @@ func TestFormats_DefaultGoTestJson(t *testing.T) {
 			name:        "standard-verbose",
 			format:      standardVerboseFormat,
 			expectedOut: "format/standard-verbose.out",
+		},
+		{
+			name: "short-verbose-with-enabled-gha",
+			format: func(out io.Writer) EventFormatter {
+				err := os.Setenv("GITHUB_ACTIONS", "true")
+				assert.NilError(t, err)
+				return NewEventFormatter(out, "short-verbose", FormatOptions{})
+			},
+			expectedOut: "format/github-actions.out",
+		},
+		{
+			name: "short-verbose-with-disabled-gha",
+			format: func(out io.Writer) EventFormatter {
+				err := os.Setenv("GITHUB_ACTIONS", "true")
+				assert.NilError(t, err)
+				return NewEventFormatter(out, "short-verbose", FormatOptions{
+					DisableGithubActionsFormat: true,
+				})
+			},
+			expectedOut: "format/short-verbose.out",
 		},
 		{
 			name:        "standard-quiet",

--- a/testjson/testdata/format/short-verbose.out
+++ b/testjson/testdata/format/short-verbose.out
@@ -1,0 +1,114 @@
+sometimes main can exit 2
+FAIL testjson/internal/badmain
+EMPTY testjson/internal/empty (cached)
+PASS testjson/internal/good.TestPassed (0.00s)
+PASS testjson/internal/good.TestPassedWithLog (0.00s)
+PASS testjson/internal/good.TestPassedWithStdout (0.00s)
+SKIP testjson/internal/good.TestSkipped (0.00s)
+SKIP testjson/internal/good.TestSkippedWitLog (0.00s)
+PASS testjson/internal/good.TestWithStderr (0.00s)
+PASS testjson/internal/good.TestNestedSuccess/a/sub (0.00s)
+PASS testjson/internal/good.TestNestedSuccess/a (0.00s)
+PASS testjson/internal/good.TestNestedSuccess/b/sub (0.00s)
+PASS testjson/internal/good.TestNestedSuccess/b (0.00s)
+PASS testjson/internal/good.TestNestedSuccess/c/sub (0.00s)
+PASS testjson/internal/good.TestNestedSuccess/c (0.00s)
+PASS testjson/internal/good.TestNestedSuccess/d/sub (0.00s)
+PASS testjson/internal/good.TestNestedSuccess/d (0.00s)
+PASS testjson/internal/good.TestNestedSuccess (0.00s)
+PASS testjson/internal/good.TestParallelTheFirst (0.01s)
+PASS testjson/internal/good.TestParallelTheThird (0.00s)
+PASS testjson/internal/good.TestParallelTheSecond (0.01s)
+PASS testjson/internal/good (cached)
+PASS testjson/internal/parallelfails.TestPassed (0.00s)
+PASS testjson/internal/parallelfails.TestPassedWithLog (0.00s)
+PASS testjson/internal/parallelfails.TestPassedWithStdout (0.00s)
+PASS testjson/internal/parallelfails.TestWithStderr (0.00s)
+=== RUN   TestNestedParallelFailures/a
+=== PAUSE TestNestedParallelFailures/a
+=== CONT  TestNestedParallelFailures/a
+    fails_test.go:50: failed sub a
+    --- FAIL: TestNestedParallelFailures/a (0.00s)
+FAIL testjson/internal/parallelfails.TestNestedParallelFailures/a (0.00s)
+=== RUN   TestNestedParallelFailures/d
+=== PAUSE TestNestedParallelFailures/d
+=== CONT  TestNestedParallelFailures/d
+    fails_test.go:50: failed sub d
+    --- FAIL: TestNestedParallelFailures/d (0.00s)
+FAIL testjson/internal/parallelfails.TestNestedParallelFailures/d (0.00s)
+=== RUN   TestNestedParallelFailures/c
+=== PAUSE TestNestedParallelFailures/c
+=== CONT  TestNestedParallelFailures/c
+    fails_test.go:50: failed sub c
+    --- FAIL: TestNestedParallelFailures/c (0.00s)
+FAIL testjson/internal/parallelfails.TestNestedParallelFailures/c (0.00s)
+=== RUN   TestNestedParallelFailures/b
+=== PAUSE TestNestedParallelFailures/b
+=== CONT  TestNestedParallelFailures/b
+    fails_test.go:50: failed sub b
+    --- FAIL: TestNestedParallelFailures/b (0.00s)
+FAIL testjson/internal/parallelfails.TestNestedParallelFailures/b (0.00s)
+=== RUN   TestNestedParallelFailures
+--- FAIL: TestNestedParallelFailures (0.00s)
+FAIL testjson/internal/parallelfails.TestNestedParallelFailures (0.00s)
+=== RUN   TestParallelTheFirst
+=== PAUSE TestParallelTheFirst
+=== CONT  TestParallelTheFirst
+    fails_test.go:29: failed the first
+--- FAIL: TestParallelTheFirst (0.01s)
+FAIL testjson/internal/parallelfails.TestParallelTheFirst (0.01s)
+=== RUN   TestParallelTheThird
+=== PAUSE TestParallelTheThird
+=== CONT  TestParallelTheThird
+    fails_test.go:41: failed the third
+--- FAIL: TestParallelTheThird (0.00s)
+FAIL testjson/internal/parallelfails.TestParallelTheThird (0.00s)
+=== RUN   TestParallelTheSecond
+=== PAUSE TestParallelTheSecond
+=== CONT  TestParallelTheSecond
+    fails_test.go:35: failed the second
+--- FAIL: TestParallelTheSecond (0.01s)
+FAIL testjson/internal/parallelfails.TestParallelTheSecond (0.01s)
+FAIL testjson/internal/parallelfails
+PASS testjson/internal/withfails.TestPassed (0.00s)
+PASS testjson/internal/withfails.TestPassedWithLog (0.00s)
+PASS testjson/internal/withfails.TestPassedWithStdout (0.00s)
+SKIP testjson/internal/withfails.TestSkipped (0.00s)
+SKIP testjson/internal/withfails.TestSkippedWitLog (0.00s)
+=== RUN   TestFailed
+    fails_test.go:34: this failed
+--- FAIL: TestFailed (0.00s)
+FAIL testjson/internal/withfails.TestFailed (0.00s)
+PASS testjson/internal/withfails.TestWithStderr (0.00s)
+=== RUN   TestFailedWithStderr
+this is stderr
+    fails_test.go:43: also failed
+--- FAIL: TestFailedWithStderr (0.00s)
+FAIL testjson/internal/withfails.TestFailedWithStderr (0.00s)
+PASS testjson/internal/withfails.TestNestedWithFailure/a/sub (0.00s)
+PASS testjson/internal/withfails.TestNestedWithFailure/a (0.00s)
+PASS testjson/internal/withfails.TestNestedWithFailure/b/sub (0.00s)
+PASS testjson/internal/withfails.TestNestedWithFailure/b (0.00s)
+=== RUN   TestNestedWithFailure/c
+    fails_test.go:65: failed
+    --- FAIL: TestNestedWithFailure/c (0.00s)
+FAIL testjson/internal/withfails.TestNestedWithFailure/c (0.00s)
+PASS testjson/internal/withfails.TestNestedWithFailure/d/sub (0.00s)
+PASS testjson/internal/withfails.TestNestedWithFailure/d (0.00s)
+=== RUN   TestNestedWithFailure
+--- FAIL: TestNestedWithFailure (0.00s)
+FAIL testjson/internal/withfails.TestNestedWithFailure (0.00s)
+PASS testjson/internal/withfails.TestNestedSuccess/a/sub (0.00s)
+PASS testjson/internal/withfails.TestNestedSuccess/a (0.00s)
+PASS testjson/internal/withfails.TestNestedSuccess/b/sub (0.00s)
+PASS testjson/internal/withfails.TestNestedSuccess/b (0.00s)
+PASS testjson/internal/withfails.TestNestedSuccess/c/sub (0.00s)
+PASS testjson/internal/withfails.TestNestedSuccess/c (0.00s)
+PASS testjson/internal/withfails.TestNestedSuccess/d/sub (0.00s)
+PASS testjson/internal/withfails.TestNestedSuccess/d (0.00s)
+PASS testjson/internal/withfails.TestNestedSuccess (0.00s)
+SKIP testjson/internal/withfails.TestTimeout (0.00s)
+PASS testjson/internal/withfails.TestParallelTheFirst (0.01s)
+PASS testjson/internal/withfails.TestParallelTheThird (0.00s)
+PASS testjson/internal/withfails.TestParallelTheSecond (0.01s)
+FAIL testjson/internal/withfails


### PR DESCRIPTION
## Overview

Adds a new `--format-disable-gha` flag to optionally disable the `github-actions` formatter override when running with `--format testname` or `--format short-verbose` in GitHub actions.

An existing workaround for this is to manually set `GITHUB_ACTIONS=false`, but this is a bit hacky. This PR makes disabling this functionality explicit, and adds some documentation to make this behavior less confusing for the next person.