### PR TITLE
feat: add the `--rerun-fails-abort-on-data-race` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,9 @@ To avoid re-running tests when there are real failures, the re-run will be
 skipped when there are too many test failures. By default this value is 10, and
 can be changed with `--rerun-fails-max-failures=n`.
 
+You may use the `--rerun-fails-abort-on-data-race` flag to abort the re-run if
+a data race is detected.
+
 Note that using `--rerun-fails` may require the use of other flags, depending on
 how you specify args to `go test`:
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -114,6 +114,8 @@ func setupFlags(name string) (*pflag.FlagSet, *options) {
 
 	flags.IntVar(&opts.rerunFailsMaxAttempts, "rerun-fails", 0,
 		"rerun failed tests until they all pass, or attempts exceeds maximum. Defaults to max 2 reruns when enabled")
+	flags.BoolVar(&opts.rerunFailsAbortOnDataRace, "rerun-fails-abort-on-data-race", false,
+		"do not rerun tests if a data race is detected")
 	flags.Lookup("rerun-fails").NoOptDefVal = "2"
 	flags.IntVar(&opts.rerunFailsMaxInitialFailures, "rerun-fails-max-failures", 10,
 		"do not rerun any tests if the initial run has more than this number of failures")
@@ -195,6 +197,7 @@ type options struct {
 	rerunFailsMaxInitialFailures int
 	rerunFailsReportFile         string
 	rerunFailsRunRootCases       bool
+	rerunFailsAbortOnDataRace    bool
 	packages                     []string
 	watch                        bool
 	watchChdir                   bool
@@ -300,7 +303,7 @@ func run(opts *options) error {
 	if exitErr == nil || opts.rerunFailsMaxAttempts == 0 {
 		return finishRun(opts, exec, exitErr)
 	}
-	if err := hasErrors(exitErr, exec); err != nil {
+	if err := hasErrors(exitErr, exec, opts); err != nil {
 		return finishRun(opts, exec, err)
 	}
 

--- a/cmd/rerunfails.go
+++ b/cmd/rerunfails.go
@@ -83,7 +83,7 @@ func rerunFailed(ctx context.Context, opts *options, scanConfig testjson.ScanCon
 			if exitErr != nil {
 				nextRec.lastErr = exitErr
 			}
-			if err := hasErrors(exitErr, scanConfig.Execution); err != nil {
+			if err := hasErrors(exitErr, scanConfig.Execution, opts); err != nil {
 				return err
 			}
 		}
@@ -95,7 +95,7 @@ func rerunFailed(ctx context.Context, opts *options, scanConfig testjson.ScanCon
 // startGoTestFn is a shim for testing
 var startGoTestFn = startGoTest
 
-func hasErrors(err error, exec *testjson.Execution) error {
+func hasErrors(err error, exec *testjson.Execution, opts *options) error {
 	switch {
 	case len(exec.Errors()) > 0:
 		return fmt.Errorf("rerun aborted because previous run had errors")
@@ -104,6 +104,8 @@ func hasErrors(err error, exec *testjson.Execution) error {
 		return fmt.Errorf("unexpected go test exit code: %v", err)
 	case exec.HasPanic():
 		return fmt.Errorf("rerun aborted because previous run had a suspected panic and some test may not have run")
+	case exec.HasDataRace() && opts.rerunFailsMaxAttempts > 0 && opts.rerunFailsAbortOnDataRace:
+		return fmt.Errorf("rerun aborted because previous run had a data race")
 	default:
 		return nil
 	}

--- a/cmd/testdata/gotestsum-help-text
+++ b/cmd/testdata/gotestsum-help-text
@@ -24,6 +24,7 @@ Flags:
       --post-run-command command                    command to run after the tests have completed
       --raw-command                                 don't prepend 'go test -json' to the 'go test' command
       --rerun-fails int[=2]                         rerun failed tests until they all pass, or attempts exceeds maximum. Defaults to max 2 reruns when enabled
+      --rerun-fails-abort-on-data-race              do not rerun tests if a data race is detected
       --rerun-fails-max-failures int                do not rerun any tests if the initial run has more than this number of failures (default 10)
       --rerun-fails-report string                   write a report to the file, of the tests that were rerun
       --rerun-fails-run-root-test                   rerun the entire root testcase when any of its subtests fail, instead of only the failed subtest


### PR DESCRIPTION
This PR implements the `--rerun-fails-abort-on-data-race` flag. When a race condition is detected, the flag stops re-running failed tests and fails the entire test run.

My motivation for adding this flag is to let `gotestsum` work with race tests that should fail when a data race is found but retry when a test fails for other reasons. In my specific use case, I run a CI test suite where some tests fail due to transient issues, such as network errors; those can be retried and do not require an engineer’s attention. A race condition, however, signals a bug in concurrent code and should notify an engineer.