### PR TITLE
feat: add support for running failed tests first based on previous ru…

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch Package",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "args": ["--rerun-fails"],
+            "program": "${workspaceFolder}/main.go"
+        }
+    ]
+}

--- a/cmd/rerunfails_test.go
+++ b/cmd/rerunfails_test.go
@@ -192,13 +192,3 @@ func (e exitCodeError) ExitCode() int {
 func newExitCode(msg string, code int) error {
 	return exitCodeError{error: fmt.Errorf("%v", msg), code: code}
 }
-
-type noopHandler struct{}
-
-func (s noopHandler) Event(testjson.TestEvent, *testjson.Execution) error {
-	return nil
-}
-
-func (s noopHandler) Err(string) error {
-	return nil
-}

--- a/cmd/testdata/gotestsum-help-text
+++ b/cmd/testdata/gotestsum-help-text
@@ -6,6 +6,7 @@ See https://pkg.go.dev/gotest.tools/gotestsum#section-readme for detailed docume
 
 Flags:
       --debug                                       enabled debug logging
+      --failed-first string                         path to previous run's JSON file. Failed tests from this file will be run first
   -f, --format string                               print format of test input (default "pkgname")
       --format-hide-empty-pkg                       do not print empty packages in compact formats
       --format-icons string                         use different icons, see help for options


### PR DESCRIPTION
…n JSON file

- Introduced a new flag `--failed-first` to specify the path to a JSON file containing the results of the previous test run.
- Implemented logic to read the JSON file and prioritize running failed tests before executing all tests.
- Added unit tests to validate the new functionality and ensure correct behavior when handling various scenarios, including no failed tests and invalid file paths.
- Updated help text to include the new flag description.