### PR TITLE
Show correct version when installed via `go install`

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"runtime/debug"
 	"strings"
 	"sync/atomic"
 	"syscall"
@@ -17,8 +18,6 @@ import (
 	"gotest.tools/gotestsum/internal/log"
 	"gotest.tools/gotestsum/testjson"
 )
-
-var version = "dev"
 
 func Run(name string, args []string) error {
 	flags, opts := setupFlags(name)
@@ -34,8 +33,12 @@ func Run(name string, args []string) error {
 
 	switch {
 	case opts.version:
-		fmt.Fprintf(os.Stdout, "gotestsum version %s\n", version)
-		return nil
+		info, ok := debug.ReadBuildInfo()
+		if !ok {
+			return fmt.Errorf("failed to read version info")
+		} else {
+			fmt.Fprintf(os.Stdout, "gotestsum version %s\n", info.Main.Version)
+		}
 	case opts.watch:
 		return runWatcher(opts)
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -36,9 +36,9 @@ func Run(name string, args []string) error {
 		info, ok := debug.ReadBuildInfo()
 		if !ok {
 			return fmt.Errorf("failed to read version info")
-		} else {
-			fmt.Fprintf(os.Stdout, "gotestsum version %s\n", info.Main.Version)
 		}
+		fmt.Fprintf(os.Stdout, "gotestsum version %s\n", info.Main.Version)
+		return nil
 	case opts.watch:
 		return runWatcher(opts)
 	}


### PR DESCRIPTION
Currently, the version information is provided via `ldflags`, which does not work for users who install `gotestsum` using `go install`. This PR changes the version retrieval to use the `fmt/debug` package, allowing users to see the correct version information regardless of the installation method.

Example output for a local build:
```bash
> gotestsum --version
gotestsum version (devel)
```

Example output when installed with go install:
```bash
> gotestsum --version
gotestsum version v1.7.5
```

Related Issue: https://github.com/gotestyourself/gotestsum/issues/503