### PR TITLE
feat: buildkite output format

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -161,6 +161,8 @@ Formats:
     testname                 print a line for each test and package
     testdox                  print a sentence for each test using gotestdox
     github-actions           testname format with github actions log grouping
+    buildkite                testname format with buildkite log grouping excluding passed test output
+    buildkite-verbose        testname format with buildkite log grouping including passed test output
     standard-quiet           standard go test format
     standard-verbose         standard go test -v format
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -338,7 +338,10 @@ func run(opts *options) error {
 }
 
 func finishRun(opts *options, exec *testjson.Execution, exitErr error) error {
-	testjson.PrintSummary(opts.stdout, exec, opts.hideSummary.value)
+	testjson.PrintSummaryWithOpts(opts.stdout, exec, testjson.SummaryOptions{
+		Summary: opts.hideSummary.value,
+		Format:  opts.format,
+	})
 
 	if err := writeJUnitFile(opts, exec); err != nil {
 		return fmt.Errorf("failed to write junit file: %w", err)

--- a/cmd/rerunfails.go
+++ b/cmd/rerunfails.go
@@ -58,7 +58,10 @@ func rerunFailed(ctx context.Context, opts *options, scanConfig testjson.ScanCon
 
 	rec := newFailureRecorderFromExecution(scanConfig.Execution)
 	for attempts := 0; rec.count() > 0 && attempts < opts.rerunFailsMaxAttempts; attempts++ {
-		testjson.PrintSummary(opts.stdout, scanConfig.Execution, testjson.SummarizeNone)
+		testjson.PrintSummaryWithOpts(opts.stdout, scanConfig.Execution, testjson.SummaryOptions{
+			Summary: testjson.SummarizeNone,
+			Format:  opts.format,
+		})
 		opts.stdout.Write([]byte("\n")) //nolint:errcheck
 
 		nextRec := newFailureRecorder(scanConfig.Handler)

--- a/cmd/testdata/gotestsum-help-text
+++ b/cmd/testdata/gotestsum-help-text
@@ -41,6 +41,8 @@ Formats:
     testname                 print a line for each test and package
     testdox                  print a sentence for each test using gotestdox
     github-actions           testname format with github actions log grouping
+    buildkite                testname format with buildkite log grouping excluding passed test output
+    buildkite-verbose        testname format with buildkite log grouping including passed test output
     standard-quiet           standard go test format
     standard-verbose         standard go test -v format
 

--- a/testjson/format.go
+++ b/testjson/format.go
@@ -537,7 +537,7 @@ func buildkiteFormat(out io.Writer, verbose bool) EventFormatter {
 
 	printOutput := func(output []string, didNotPass bool) {
 		if verbose || didNotPass {
-			// prevert erroneous groups from test output by prefixing lines with markers by an empty string
+			// prevent erroneous groups from test output by prefixing lines with markers by an empty string
 			for _, item := range output {
 				for _, bkMarker := range markers {
 					if strings.HasPrefix(item, bkMarker) {
@@ -549,7 +549,6 @@ func buildkiteFormat(out io.Writer, verbose bool) EventFormatter {
 		}
 	}
 
-	//nolint:errcheck
 	return eventFormatterFunc(func(event TestEvent, exec *Execution) error {
 		key := name{Package: event.Package, Test: event.Test}
 

--- a/testjson/format.go
+++ b/testjson/format.go
@@ -449,6 +449,10 @@ func NewEventFormatter(out io.Writer, format string, formatOpts FormatOptions) E
 		return pkgNameWithFailuresFormat(out, formatOpts)
 	case "github-actions", "github-action":
 		return githubActionsFormat(out)
+	case "buildkite":
+		return buildkiteFormat(out, false)
+	case "buildkite-verbose":
+		return buildkiteFormat(out, true)
 	default:
 		return nil
 	}
@@ -510,6 +514,95 @@ func githubActionsFormat(out io.Writer) EventFormatter {
 		buf.WriteString(" Package ")
 		buf.WriteString(packageLine(event, exec.Package(event.Package)))
 		buf.WriteString("\n")
+		return buf.Flush()
+	})
+}
+
+func buildkiteFormat(out io.Writer, verbose bool) EventFormatter {
+	const (
+		bkMarkerDeemphasized = "~~~"
+		bkMarkerCollapsed    = "---"
+		bkMarkerExpanded     = "+++"
+	)
+	markers := [3]string{bkMarkerDeemphasized, bkMarkerCollapsed, bkMarkerExpanded}
+
+	buf := bufio.NewWriter(out)
+
+	type name struct {
+		Package string
+		Test    string
+	}
+	output := map[name][]string{}
+	packageOutput := map[string][]string{}
+
+	printOutput := func(output []string, didNotPass bool) {
+		if verbose || didNotPass {
+			// prevert erroneous groups from test output by prefixing lines with markers by an empty string
+			for _, item := range output {
+				for _, bkMarker := range markers {
+					if strings.HasPrefix(item, bkMarker) {
+						buf.WriteString(" ")
+					}
+				}
+				buf.WriteString(item)
+			}
+		}
+	}
+
+	//nolint:errcheck
+	return eventFormatterFunc(func(event TestEvent, exec *Execution) error {
+		key := name{Package: event.Package, Test: event.Test}
+
+		// test case event
+		if event.Test != "" {
+			if event.Action == ActionOutput {
+				if !isFramingLine(event.Output, event.Test) {
+					output[key] = append(output[key], event.Output)
+				}
+				return nil
+			}
+
+			if event.Action.IsTerminal() {
+				marker := bkMarkerDeemphasized
+				switch event.Action {
+				case ActionFail:
+					marker = bkMarkerCollapsed
+				}
+				buf.WriteString(marker)
+				buf.WriteString(" ")
+				testNameFormatTestEvent(buf, event)
+				printOutput(output[key], event.Action != ActionPass)
+				delete(output, key)
+				return buf.Flush()
+			}
+
+			return nil
+		}
+		// package event
+
+		if event.Action == ActionOutput {
+			packageOutput[event.Package] = append(packageOutput[event.Package], event.Output)
+			return nil
+		}
+		if !event.Action.IsTerminal() {
+			return nil
+		}
+
+		marker := bkMarkerDeemphasized
+		switch event.Action {
+		case ActionFail:
+			marker = bkMarkerCollapsed
+		}
+
+		result := colorEvent(event)(strings.ToUpper(string(event.Action)))
+		pkg := exec.Package(event.Package)
+		if event.Action == ActionSkip || (event.Action == ActionPass && pkg.Total == 0) {
+			event.Action = ActionSkip // always color these as skip actions
+			result = colorEvent(event)("EMPTY")
+		}
+
+		fmt.Fprintf(buf, "%s %s Package %s", marker, result, packageLine(event, exec.Package(event.Package)))
+		printOutput(packageOutput[event.Package], event.Action != ActionPass)
 		return buf.Flush()
 	})
 }

--- a/testjson/format_test.go
+++ b/testjson/format_test.go
@@ -172,6 +172,16 @@ func TestFormats_DefaultGoTestJson(t *testing.T) {
 			format:      githubActionsFormat,
 			expectedOut: "format/github-actions.out",
 		},
+		{
+			name:        "buildkite-verbose",
+			format:      func(out io.Writer) EventFormatter { return buildkiteFormat(out, true) },
+			expectedOut: "format/buildkite-verbose.out",
+		},
+		{
+			name:        "buildkite",
+			format:      func(out io.Writer) EventFormatter { return buildkiteFormat(out, false) },
+			expectedOut: "format/buildkite.out",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/testjson/summary.go
+++ b/testjson/summary.go
@@ -64,19 +64,36 @@ func NewSummary(value string) (Summary, bool) {
 	return s, ok
 }
 
+type SummaryPrinter func(out io.Writer, execution *Execution, opts Summary)
+
+type SummaryOptions struct {
+	Summary Summary
+	Format  string
+}
+
+// PrintSummaryWithOpts prints the summary of a test Execution with specific options.
+func PrintSummaryWithOpts(out io.Writer, execution *Execution, opts SummaryOptions) {
+	switch opts.Format {
+	case "buildkite", "buildkite-verbose":
+		// put the summary into an expanded section
+		fmt.Fprintln(out, "+++ Summary")
+	}
+	PrintSummary(out, execution, opts.Summary)
+}
+
 // PrintSummary of a test Execution. Prints a section for each summary type
 // followed by a DONE line to out.
-func PrintSummary(out io.Writer, execution *Execution, opts Summary) {
-	execSummary := newExecSummary(execution, opts)
-	if opts.Includes(SummarizeSkipped) {
+func PrintSummary(out io.Writer, execution *Execution, summary Summary) {
+	execSummary := newExecSummary(execution, summary)
+	if summary.Includes(SummarizeSkipped) {
 		writeTestCaseSummary(out, execSummary, formatSkipped())
 	}
-	if opts.Includes(SummarizeFailed) {
+	if summary.Includes(SummarizeFailed) {
 		writeTestCaseSummary(out, execSummary, formatFailed())
 	}
 
 	errors := execution.Errors()
-	if opts.Includes(SummarizeErrors) {
+	if summary.Includes(SummarizeErrors) {
 		writeErrorSummary(out, errors)
 	}
 

--- a/testjson/summary_test.go
+++ b/testjson/summary_test.go
@@ -2,6 +2,7 @@ package testjson
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -315,6 +316,32 @@ func TestPrintSummary(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			run(t, tc)
+		})
+	}
+}
+
+func TestSummary_Formats_DefaultGoTestJson(t *testing.T) {
+	run := func(t *testing.T, format string) {
+		exec, err := ScanTestOutput(scanConfigFromGolden("input/go-test-json.out")(t))
+		assert.NilError(t, err)
+
+		var out bytes.Buffer
+		PrintSummaryWithOpts(&out, exec, SummaryOptions{
+			Summary: SummarizeAll,
+			Format:  format,
+		})
+		golden.Assert(t, out.String(), fmt.Sprintf("format-summary/%s.out", format))
+	}
+
+	formats := []string{
+		"none",
+		"buildkite",
+		"buildkite-verbose",
+	}
+
+	for _, format := range formats {
+		t.Run(format, func(t *testing.T) {
+			run(t, format)
 		})
 	}
 }

--- a/testjson/testdata/format-summary/buildkite-verbose.out
+++ b/testjson/testdata/format-summary/buildkite-verbose.out
@@ -1,0 +1,64 @@
++++ Summary
+
+=== Skipped
+=== SKIP: testjson/internal/good TestSkipped (0.00s)
+    good_test.go:23: 
+
+=== SKIP: testjson/internal/good TestSkippedWitLog (0.00s)
+    good_test.go:27: the skip message
+
+=== SKIP: testjson/internal/withfails TestSkipped (0.00s)
+    fails_test.go:26: 
+
+=== SKIP: testjson/internal/withfails TestSkippedWitLog (0.00s)
+    fails_test.go:30: the skip message
+
+=== SKIP: testjson/internal/withfails TestTimeout (0.00s)
+    timeout_test.go:13: skipping slow test
+
+=== Failed
+=== FAIL: testjson/internal/badmain  (0.00s)
+sometimes main can exit 2
+FAIL	gotest.tools/gotestsum/testjson/internal/badmain	0.001s
+
+=== FAIL: testjson/internal/parallelfails TestNestedParallelFailures/a (0.00s)
+    fails_test.go:50: failed sub a
+    --- FAIL: TestNestedParallelFailures/a (0.00s)
+
+=== FAIL: testjson/internal/parallelfails TestNestedParallelFailures/d (0.00s)
+    fails_test.go:50: failed sub d
+    --- FAIL: TestNestedParallelFailures/d (0.00s)
+
+=== FAIL: testjson/internal/parallelfails TestNestedParallelFailures/c (0.00s)
+    fails_test.go:50: failed sub c
+    --- FAIL: TestNestedParallelFailures/c (0.00s)
+
+=== FAIL: testjson/internal/parallelfails TestNestedParallelFailures/b (0.00s)
+    fails_test.go:50: failed sub b
+    --- FAIL: TestNestedParallelFailures/b (0.00s)
+
+=== FAIL: testjson/internal/parallelfails TestNestedParallelFailures (0.00s)
+
+=== FAIL: testjson/internal/parallelfails TestParallelTheFirst (0.01s)
+    fails_test.go:29: failed the first
+
+=== FAIL: testjson/internal/parallelfails TestParallelTheThird (0.00s)
+    fails_test.go:41: failed the third
+
+=== FAIL: testjson/internal/parallelfails TestParallelTheSecond (0.01s)
+    fails_test.go:35: failed the second
+
+=== FAIL: testjson/internal/withfails TestFailed (0.00s)
+    fails_test.go:34: this failed
+
+=== FAIL: testjson/internal/withfails TestFailedWithStderr (0.00s)
+this is stderr
+    fails_test.go:43: also failed
+
+=== FAIL: testjson/internal/withfails TestNestedWithFailure/c (0.00s)
+    fails_test.go:65: failed
+    --- FAIL: TestNestedWithFailure/c (0.00s)
+
+=== FAIL: testjson/internal/withfails TestNestedWithFailure (0.00s)
+
+DONE 59 tests, 5 skipped, 13 failures in 0.157s

--- a/testjson/testdata/format-summary/buildkite.out
+++ b/testjson/testdata/format-summary/buildkite.out
@@ -1,0 +1,64 @@
++++ Summary
+
+=== Skipped
+=== SKIP: testjson/internal/good TestSkipped (0.00s)
+    good_test.go:23: 
+
+=== SKIP: testjson/internal/good TestSkippedWitLog (0.00s)
+    good_test.go:27: the skip message
+
+=== SKIP: testjson/internal/withfails TestSkipped (0.00s)
+    fails_test.go:26: 
+
+=== SKIP: testjson/internal/withfails TestSkippedWitLog (0.00s)
+    fails_test.go:30: the skip message
+
+=== SKIP: testjson/internal/withfails TestTimeout (0.00s)
+    timeout_test.go:13: skipping slow test
+
+=== Failed
+=== FAIL: testjson/internal/badmain  (0.00s)
+sometimes main can exit 2
+FAIL	gotest.tools/gotestsum/testjson/internal/badmain	0.001s
+
+=== FAIL: testjson/internal/parallelfails TestNestedParallelFailures/a (0.00s)
+    fails_test.go:50: failed sub a
+    --- FAIL: TestNestedParallelFailures/a (0.00s)
+
+=== FAIL: testjson/internal/parallelfails TestNestedParallelFailures/d (0.00s)
+    fails_test.go:50: failed sub d
+    --- FAIL: TestNestedParallelFailures/d (0.00s)
+
+=== FAIL: testjson/internal/parallelfails TestNestedParallelFailures/c (0.00s)
+    fails_test.go:50: failed sub c
+    --- FAIL: TestNestedParallelFailures/c (0.00s)
+
+=== FAIL: testjson/internal/parallelfails TestNestedParallelFailures/b (0.00s)
+    fails_test.go:50: failed sub b
+    --- FAIL: TestNestedParallelFailures/b (0.00s)
+
+=== FAIL: testjson/internal/parallelfails TestNestedParallelFailures (0.00s)
+
+=== FAIL: testjson/internal/parallelfails TestParallelTheFirst (0.01s)
+    fails_test.go:29: failed the first
+
+=== FAIL: testjson/internal/parallelfails TestParallelTheThird (0.00s)
+    fails_test.go:41: failed the third
+
+=== FAIL: testjson/internal/parallelfails TestParallelTheSecond (0.01s)
+    fails_test.go:35: failed the second
+
+=== FAIL: testjson/internal/withfails TestFailed (0.00s)
+    fails_test.go:34: this failed
+
+=== FAIL: testjson/internal/withfails TestFailedWithStderr (0.00s)
+this is stderr
+    fails_test.go:43: also failed
+
+=== FAIL: testjson/internal/withfails TestNestedWithFailure/c (0.00s)
+    fails_test.go:65: failed
+    --- FAIL: TestNestedWithFailure/c (0.00s)
+
+=== FAIL: testjson/internal/withfails TestNestedWithFailure (0.00s)
+
+DONE 59 tests, 5 skipped, 13 failures in 0.157s

--- a/testjson/testdata/format-summary/none.out
+++ b/testjson/testdata/format-summary/none.out
@@ -1,0 +1,63 @@
+
+=== Skipped
+=== SKIP: testjson/internal/good TestSkipped (0.00s)
+    good_test.go:23: 
+
+=== SKIP: testjson/internal/good TestSkippedWitLog (0.00s)
+    good_test.go:27: the skip message
+
+=== SKIP: testjson/internal/withfails TestSkipped (0.00s)
+    fails_test.go:26: 
+
+=== SKIP: testjson/internal/withfails TestSkippedWitLog (0.00s)
+    fails_test.go:30: the skip message
+
+=== SKIP: testjson/internal/withfails TestTimeout (0.00s)
+    timeout_test.go:13: skipping slow test
+
+=== Failed
+=== FAIL: testjson/internal/badmain  (0.00s)
+sometimes main can exit 2
+FAIL	gotest.tools/gotestsum/testjson/internal/badmain	0.001s
+
+=== FAIL: testjson/internal/parallelfails TestNestedParallelFailures/a (0.00s)
+    fails_test.go:50: failed sub a
+    --- FAIL: TestNestedParallelFailures/a (0.00s)
+
+=== FAIL: testjson/internal/parallelfails TestNestedParallelFailures/d (0.00s)
+    fails_test.go:50: failed sub d
+    --- FAIL: TestNestedParallelFailures/d (0.00s)
+
+=== FAIL: testjson/internal/parallelfails TestNestedParallelFailures/c (0.00s)
+    fails_test.go:50: failed sub c
+    --- FAIL: TestNestedParallelFailures/c (0.00s)
+
+=== FAIL: testjson/internal/parallelfails TestNestedParallelFailures/b (0.00s)
+    fails_test.go:50: failed sub b
+    --- FAIL: TestNestedParallelFailures/b (0.00s)
+
+=== FAIL: testjson/internal/parallelfails TestNestedParallelFailures (0.00s)
+
+=== FAIL: testjson/internal/parallelfails TestParallelTheFirst (0.01s)
+    fails_test.go:29: failed the first
+
+=== FAIL: testjson/internal/parallelfails TestParallelTheThird (0.00s)
+    fails_test.go:41: failed the third
+
+=== FAIL: testjson/internal/parallelfails TestParallelTheSecond (0.01s)
+    fails_test.go:35: failed the second
+
+=== FAIL: testjson/internal/withfails TestFailed (0.00s)
+    fails_test.go:34: this failed
+
+=== FAIL: testjson/internal/withfails TestFailedWithStderr (0.00s)
+this is stderr
+    fails_test.go:43: also failed
+
+=== FAIL: testjson/internal/withfails TestNestedWithFailure/c (0.00s)
+    fails_test.go:65: failed
+    --- FAIL: TestNestedWithFailure/c (0.00s)
+
+=== FAIL: testjson/internal/withfails TestNestedWithFailure (0.00s)
+
+DONE 59 tests, 5 skipped, 13 failures in 0.157s

--- a/testjson/testdata/format/buildkite-verbose.out
+++ b/testjson/testdata/format/buildkite-verbose.out
@@ -1,0 +1,127 @@
+--- FAIL Package testjson/internal/badmain (1ms)
+sometimes main can exit 2
+FAIL	gotest.tools/gotestsum/testjson/internal/badmain	0.001s
+~~~ EMPTY Package testjson/internal/empty (cached)
+testing: warning: no tests to run
+PASS
+ok  	gotest.tools/gotestsum/testjson/internal/empty	(cached) [no tests to run]
+~~~ PASS testjson/internal/good.TestPassed (0.00s)
+~~~ PASS testjson/internal/good.TestPassedWithLog (0.00s)
+    good_test.go:15: this is a log
+~~~ PASS testjson/internal/good.TestPassedWithStdout (0.00s)
+this is a Print
+~~~ SKIP testjson/internal/good.TestSkipped (0.00s)
+    good_test.go:23: 
+~~~ SKIP testjson/internal/good.TestSkippedWitLog (0.00s)
+    good_test.go:27: the skip message
+~~~ PASS testjson/internal/good.TestWithStderr (0.00s)
+this is stderr
+~~~ PASS testjson/internal/good.TestNestedSuccess/a/sub (0.00s)
+        --- PASS: TestNestedSuccess/a/sub (0.00s)
+~~~ PASS testjson/internal/good.TestNestedSuccess/a (0.00s)
+    --- PASS: TestNestedSuccess/a (0.00s)
+~~~ PASS testjson/internal/good.TestNestedSuccess/b/sub (0.00s)
+        --- PASS: TestNestedSuccess/b/sub (0.00s)
+~~~ PASS testjson/internal/good.TestNestedSuccess/b (0.00s)
+    --- PASS: TestNestedSuccess/b (0.00s)
+~~~ PASS testjson/internal/good.TestNestedSuccess/c/sub (0.00s)
+        --- PASS: TestNestedSuccess/c/sub (0.00s)
+~~~ PASS testjson/internal/good.TestNestedSuccess/c (0.00s)
+    --- PASS: TestNestedSuccess/c (0.00s)
+~~~ PASS testjson/internal/good.TestNestedSuccess/d/sub (0.00s)
+        --- PASS: TestNestedSuccess/d/sub (0.00s)
+~~~ PASS testjson/internal/good.TestNestedSuccess/d (0.00s)
+    --- PASS: TestNestedSuccess/d (0.00s)
+~~~ PASS testjson/internal/good.TestNestedSuccess (0.00s)
+~~~ PASS testjson/internal/good.TestParallelTheFirst (0.01s)
+~~~ PASS testjson/internal/good.TestParallelTheThird (0.00s)
+~~~ PASS testjson/internal/good.TestParallelTheSecond (0.01s)
+~~~ PASS Package testjson/internal/good (cached)
+PASS
+ok  	gotest.tools/gotestsum/testjson/internal/good	(cached)
+~~~ PASS testjson/internal/parallelfails.TestPassed (0.00s)
+~~~ PASS testjson/internal/parallelfails.TestPassedWithLog (0.00s)
+    fails_test.go:15: this is a log
+~~~ PASS testjson/internal/parallelfails.TestPassedWithStdout (0.00s)
+this is a Print
+~~~ PASS testjson/internal/parallelfails.TestWithStderr (0.00s)
+this is stderr
+--- FAIL testjson/internal/parallelfails.TestNestedParallelFailures/a (0.00s)
+    fails_test.go:50: failed sub a
+    --- FAIL: TestNestedParallelFailures/a (0.00s)
+--- FAIL testjson/internal/parallelfails.TestNestedParallelFailures/d (0.00s)
+    fails_test.go:50: failed sub d
+    --- FAIL: TestNestedParallelFailures/d (0.00s)
+--- FAIL testjson/internal/parallelfails.TestNestedParallelFailures/c (0.00s)
+    fails_test.go:50: failed sub c
+    --- FAIL: TestNestedParallelFailures/c (0.00s)
+--- FAIL testjson/internal/parallelfails.TestNestedParallelFailures/b (0.00s)
+    fails_test.go:50: failed sub b
+    --- FAIL: TestNestedParallelFailures/b (0.00s)
+--- FAIL testjson/internal/parallelfails.TestNestedParallelFailures (0.00s)
+--- FAIL testjson/internal/parallelfails.TestParallelTheFirst (0.01s)
+    fails_test.go:29: failed the first
+--- FAIL testjson/internal/parallelfails.TestParallelTheThird (0.00s)
+    fails_test.go:41: failed the third
+--- FAIL testjson/internal/parallelfails.TestParallelTheSecond (0.01s)
+    fails_test.go:35: failed the second
+--- FAIL Package testjson/internal/parallelfails (20ms)
+FAIL
+FAIL	gotest.tools/gotestsum/testjson/internal/parallelfails	0.020s
+~~~ PASS testjson/internal/withfails.TestPassed (0.00s)
+~~~ PASS testjson/internal/withfails.TestPassedWithLog (0.00s)
+    fails_test.go:18: this is a log
+~~~ PASS testjson/internal/withfails.TestPassedWithStdout (0.00s)
+this is a Print
+~~~ SKIP testjson/internal/withfails.TestSkipped (0.00s)
+    fails_test.go:26: 
+~~~ SKIP testjson/internal/withfails.TestSkippedWitLog (0.00s)
+    fails_test.go:30: the skip message
+--- FAIL testjson/internal/withfails.TestFailed (0.00s)
+    fails_test.go:34: this failed
+~~~ PASS testjson/internal/withfails.TestWithStderr (0.00s)
+this is stderr
+--- FAIL testjson/internal/withfails.TestFailedWithStderr (0.00s)
+this is stderr
+    fails_test.go:43: also failed
+~~~ PASS testjson/internal/withfails.TestNestedWithFailure/a/sub (0.00s)
+        --- PASS: TestNestedWithFailure/a/sub (0.00s)
+~~~ PASS testjson/internal/withfails.TestNestedWithFailure/a (0.00s)
+    --- PASS: TestNestedWithFailure/a (0.00s)
+~~~ PASS testjson/internal/withfails.TestNestedWithFailure/b/sub (0.00s)
+        --- PASS: TestNestedWithFailure/b/sub (0.00s)
+~~~ PASS testjson/internal/withfails.TestNestedWithFailure/b (0.00s)
+    --- PASS: TestNestedWithFailure/b (0.00s)
+--- FAIL testjson/internal/withfails.TestNestedWithFailure/c (0.00s)
+    fails_test.go:65: failed
+    --- FAIL: TestNestedWithFailure/c (0.00s)
+~~~ PASS testjson/internal/withfails.TestNestedWithFailure/d/sub (0.00s)
+        --- PASS: TestNestedWithFailure/d/sub (0.00s)
+~~~ PASS testjson/internal/withfails.TestNestedWithFailure/d (0.00s)
+    --- PASS: TestNestedWithFailure/d (0.00s)
+--- FAIL testjson/internal/withfails.TestNestedWithFailure (0.00s)
+~~~ PASS testjson/internal/withfails.TestNestedSuccess/a/sub (0.00s)
+        --- PASS: TestNestedSuccess/a/sub (0.00s)
+~~~ PASS testjson/internal/withfails.TestNestedSuccess/a (0.00s)
+    --- PASS: TestNestedSuccess/a (0.00s)
+~~~ PASS testjson/internal/withfails.TestNestedSuccess/b/sub (0.00s)
+        --- PASS: TestNestedSuccess/b/sub (0.00s)
+~~~ PASS testjson/internal/withfails.TestNestedSuccess/b (0.00s)
+    --- PASS: TestNestedSuccess/b (0.00s)
+~~~ PASS testjson/internal/withfails.TestNestedSuccess/c/sub (0.00s)
+        --- PASS: TestNestedSuccess/c/sub (0.00s)
+~~~ PASS testjson/internal/withfails.TestNestedSuccess/c (0.00s)
+    --- PASS: TestNestedSuccess/c (0.00s)
+~~~ PASS testjson/internal/withfails.TestNestedSuccess/d/sub (0.00s)
+        --- PASS: TestNestedSuccess/d/sub (0.00s)
+~~~ PASS testjson/internal/withfails.TestNestedSuccess/d (0.00s)
+    --- PASS: TestNestedSuccess/d (0.00s)
+~~~ PASS testjson/internal/withfails.TestNestedSuccess (0.00s)
+~~~ SKIP testjson/internal/withfails.TestTimeout (0.00s)
+    timeout_test.go:13: skipping slow test
+~~~ PASS testjson/internal/withfails.TestParallelTheFirst (0.01s)
+~~~ PASS testjson/internal/withfails.TestParallelTheThird (0.00s)
+~~~ PASS testjson/internal/withfails.TestParallelTheSecond (0.01s)
+--- FAIL Package testjson/internal/withfails (20ms)
+FAIL
+FAIL	gotest.tools/gotestsum/testjson/internal/withfails	0.020s

--- a/testjson/testdata/format/buildkite.out
+++ b/testjson/testdata/format/buildkite.out
@@ -1,0 +1,94 @@
+--- FAIL Package testjson/internal/badmain (1ms)
+sometimes main can exit 2
+FAIL	gotest.tools/gotestsum/testjson/internal/badmain	0.001s
+~~~ EMPTY Package testjson/internal/empty (cached)
+testing: warning: no tests to run
+PASS
+ok  	gotest.tools/gotestsum/testjson/internal/empty	(cached) [no tests to run]
+~~~ PASS testjson/internal/good.TestPassed (0.00s)
+~~~ PASS testjson/internal/good.TestPassedWithLog (0.00s)
+~~~ PASS testjson/internal/good.TestPassedWithStdout (0.00s)
+~~~ SKIP testjson/internal/good.TestSkipped (0.00s)
+    good_test.go:23: 
+~~~ SKIP testjson/internal/good.TestSkippedWitLog (0.00s)
+    good_test.go:27: the skip message
+~~~ PASS testjson/internal/good.TestWithStderr (0.00s)
+~~~ PASS testjson/internal/good.TestNestedSuccess/a/sub (0.00s)
+~~~ PASS testjson/internal/good.TestNestedSuccess/a (0.00s)
+~~~ PASS testjson/internal/good.TestNestedSuccess/b/sub (0.00s)
+~~~ PASS testjson/internal/good.TestNestedSuccess/b (0.00s)
+~~~ PASS testjson/internal/good.TestNestedSuccess/c/sub (0.00s)
+~~~ PASS testjson/internal/good.TestNestedSuccess/c (0.00s)
+~~~ PASS testjson/internal/good.TestNestedSuccess/d/sub (0.00s)
+~~~ PASS testjson/internal/good.TestNestedSuccess/d (0.00s)
+~~~ PASS testjson/internal/good.TestNestedSuccess (0.00s)
+~~~ PASS testjson/internal/good.TestParallelTheFirst (0.01s)
+~~~ PASS testjson/internal/good.TestParallelTheThird (0.00s)
+~~~ PASS testjson/internal/good.TestParallelTheSecond (0.01s)
+~~~ PASS Package testjson/internal/good (cached)
+~~~ PASS testjson/internal/parallelfails.TestPassed (0.00s)
+~~~ PASS testjson/internal/parallelfails.TestPassedWithLog (0.00s)
+~~~ PASS testjson/internal/parallelfails.TestPassedWithStdout (0.00s)
+~~~ PASS testjson/internal/parallelfails.TestWithStderr (0.00s)
+--- FAIL testjson/internal/parallelfails.TestNestedParallelFailures/a (0.00s)
+    fails_test.go:50: failed sub a
+    --- FAIL: TestNestedParallelFailures/a (0.00s)
+--- FAIL testjson/internal/parallelfails.TestNestedParallelFailures/d (0.00s)
+    fails_test.go:50: failed sub d
+    --- FAIL: TestNestedParallelFailures/d (0.00s)
+--- FAIL testjson/internal/parallelfails.TestNestedParallelFailures/c (0.00s)
+    fails_test.go:50: failed sub c
+    --- FAIL: TestNestedParallelFailures/c (0.00s)
+--- FAIL testjson/internal/parallelfails.TestNestedParallelFailures/b (0.00s)
+    fails_test.go:50: failed sub b
+    --- FAIL: TestNestedParallelFailures/b (0.00s)
+--- FAIL testjson/internal/parallelfails.TestNestedParallelFailures (0.00s)
+--- FAIL testjson/internal/parallelfails.TestParallelTheFirst (0.01s)
+    fails_test.go:29: failed the first
+--- FAIL testjson/internal/parallelfails.TestParallelTheThird (0.00s)
+    fails_test.go:41: failed the third
+--- FAIL testjson/internal/parallelfails.TestParallelTheSecond (0.01s)
+    fails_test.go:35: failed the second
+--- FAIL Package testjson/internal/parallelfails (20ms)
+FAIL
+FAIL	gotest.tools/gotestsum/testjson/internal/parallelfails	0.020s
+~~~ PASS testjson/internal/withfails.TestPassed (0.00s)
+~~~ PASS testjson/internal/withfails.TestPassedWithLog (0.00s)
+~~~ PASS testjson/internal/withfails.TestPassedWithStdout (0.00s)
+~~~ SKIP testjson/internal/withfails.TestSkipped (0.00s)
+    fails_test.go:26: 
+~~~ SKIP testjson/internal/withfails.TestSkippedWitLog (0.00s)
+    fails_test.go:30: the skip message
+--- FAIL testjson/internal/withfails.TestFailed (0.00s)
+    fails_test.go:34: this failed
+~~~ PASS testjson/internal/withfails.TestWithStderr (0.00s)
+--- FAIL testjson/internal/withfails.TestFailedWithStderr (0.00s)
+this is stderr
+    fails_test.go:43: also failed
+~~~ PASS testjson/internal/withfails.TestNestedWithFailure/a/sub (0.00s)
+~~~ PASS testjson/internal/withfails.TestNestedWithFailure/a (0.00s)
+~~~ PASS testjson/internal/withfails.TestNestedWithFailure/b/sub (0.00s)
+~~~ PASS testjson/internal/withfails.TestNestedWithFailure/b (0.00s)
+--- FAIL testjson/internal/withfails.TestNestedWithFailure/c (0.00s)
+    fails_test.go:65: failed
+    --- FAIL: TestNestedWithFailure/c (0.00s)
+~~~ PASS testjson/internal/withfails.TestNestedWithFailure/d/sub (0.00s)
+~~~ PASS testjson/internal/withfails.TestNestedWithFailure/d (0.00s)
+--- FAIL testjson/internal/withfails.TestNestedWithFailure (0.00s)
+~~~ PASS testjson/internal/withfails.TestNestedSuccess/a/sub (0.00s)
+~~~ PASS testjson/internal/withfails.TestNestedSuccess/a (0.00s)
+~~~ PASS testjson/internal/withfails.TestNestedSuccess/b/sub (0.00s)
+~~~ PASS testjson/internal/withfails.TestNestedSuccess/b (0.00s)
+~~~ PASS testjson/internal/withfails.TestNestedSuccess/c/sub (0.00s)
+~~~ PASS testjson/internal/withfails.TestNestedSuccess/c (0.00s)
+~~~ PASS testjson/internal/withfails.TestNestedSuccess/d/sub (0.00s)
+~~~ PASS testjson/internal/withfails.TestNestedSuccess/d (0.00s)
+~~~ PASS testjson/internal/withfails.TestNestedSuccess (0.00s)
+~~~ SKIP testjson/internal/withfails.TestTimeout (0.00s)
+    timeout_test.go:13: skipping slow test
+~~~ PASS testjson/internal/withfails.TestParallelTheFirst (0.01s)
+~~~ PASS testjson/internal/withfails.TestParallelTheThird (0.00s)
+~~~ PASS testjson/internal/withfails.TestParallelTheSecond (0.01s)
+--- FAIL Package testjson/internal/withfails (20ms)
+FAIL
+FAIL	gotest.tools/gotestsum/testjson/internal/withfails	0.020s


### PR DESCRIPTION
This PR introduces two new output formats that properly collapse test output on [buildkite](https://buildkite.com/docs/pipelines/configure/managing-log-output). There's a quitet variant (`--buildkite`) that suppresses output from passed tests and a verbose one (`--buildkite-verbose`) that prints everything.

I also added some plumbing to enable overriding the summary for a specific format. This is needed to put the summary into a separate section in buildkite rather that under the last test output.

Addresses #316 partly 
