### PR TITLE
Implement error reporter format for GitHub Actions

### DIFF
--- a/testjson/format.go
+++ b/testjson/format.go
@@ -602,7 +602,7 @@ func writeGitHubActionsError(
 		}
 	} else {
 		// For regular test failures, emit one annotation per error line
-		for _, outputLine := range outputLines {
+		for idx, outputLine := range outputLines {
 			if matches := patterns.fileLine.FindStringSubmatch(outputLine); len(matches) == 3 {
 				file := matches[1]
 				line := matches[2]
@@ -620,6 +620,9 @@ func writeGitHubActionsError(
 					message = strings.TrimSpace(parts[2])
 				}
 				if message == "" {
+					message = collectAdditionalMessage(outputLines[idx+1:], patterns)
+				}
+				if message == "" {
 					message = "Test failed"
 				}
 
@@ -628,4 +631,32 @@ func writeGitHubActionsError(
 			}
 		}
 	}
+}
+
+func collectAdditionalMessage(lines []string, patterns githubActionsErrorPatterns) string {
+	var parts []string
+	shouldStop := func(line string, trimmed string) bool {
+		if trimmed == "" {
+			return true
+		}
+		if patterns.fileLine.MatchString(line) || patterns.panicStack.MatchString(line) {
+			return true
+		}
+		if strings.HasPrefix(trimmed, "PASS ") || strings.HasPrefix(trimmed, "FAIL ") ||
+			strings.HasPrefix(trimmed, "SKIP ") || strings.HasPrefix(trimmed, "=== ") ||
+			strings.HasPrefix(trimmed, "--- ") || strings.HasPrefix(trimmed, "::") {
+			return true
+		}
+		return false
+	}
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if shouldStop(line, trimmed) {
+			break
+		}
+		parts = append(parts, trimmed)
+	}
+
+	return strings.Join(parts, " ")
 }

--- a/testjson/format.go
+++ b/testjson/format.go
@@ -528,7 +528,9 @@ func githubActionsFormat(out io.Writer) EventFormatter {
 }
 
 // writeGitHubActionsError parses test output and emits GitHub Actions error annotations
-func writeGitHubActionsError(buf *bufio.Writer, event TestEvent, outputLines []string, fileLinePattern, panicStackPattern *regexp.Regexp) {
+func writeGitHubActionsError(
+	buf *bufio.Writer, event TestEvent, outputLines []string, fileLinePattern, panicStackPattern *regexp.Regexp,
+) {
 	sanitize := func(s string) string {
 		// Percent must be escaped first
 		s = strings.ReplaceAll(s, "%", "%25")

--- a/testjson/format.go
+++ b/testjson/format.go
@@ -574,12 +574,14 @@ func writeGitHubActionsError(
 		// Prefer _test.go files over other files (like testing.go or runtime files)
 		for _, outputLine := range outputLines {
 			if matches := patterns.panicStack.FindStringSubmatch(outputLine); len(matches) == 3 {
-				stackFile := filepath.Base(matches[1])
+				stackPath := filepath.ToSlash(matches[1])
+				stackFile := filepath.Base(stackPath)
 				stackLine := matches[2]
 				isTestFile := strings.HasSuffix(stackFile, "_test.go")
+				repoRelative := repoRelativeFile(event, stackPath)
 
-				if file == "" || isTestFile {
-					file = stackFile
+				if (file == "" && repoRelative != "") || isTestFile {
+					file = repoRelative
 					line = stackLine
 
 					if isTestFile {
@@ -604,7 +606,8 @@ func writeGitHubActionsError(
 		// For regular test failures, emit one annotation per error line
 		for idx, outputLine := range outputLines {
 			if matches := patterns.fileLine.FindStringSubmatch(outputLine); len(matches) == 3 {
-				file := matches[1]
+				rawFile := matches[1]
+				file := repoRelativeFile(event, rawFile)
 				line := matches[2]
 
 				// Ignore logs or helper output from non-test files; these are often
@@ -659,4 +662,27 @@ func collectAdditionalMessage(lines []string, patterns githubActionsErrorPattern
 	}
 
 	return strings.Join(parts, " ")
+}
+
+func repoRelativeFile(event TestEvent, file string) string {
+	clean := filepath.ToSlash(file)
+	clean = strings.TrimPrefix(clean, "./")
+	if clean == "" {
+		return ""
+	}
+	pkgPath := RelativePackagePath(event.Package)
+	pkgPath = strings.TrimPrefix(pkgPath, "./")
+	if pkgPath == "" || pkgPath == "." {
+		if strings.HasPrefix(clean, "/") || strings.Contains(clean, ":") {
+			return filepath.Base(clean)
+		}
+		return clean
+	}
+	if idx := strings.Index(clean, pkgPath+"/"); idx >= 0 {
+		return clean[idx:]
+	}
+	if !strings.Contains(clean, "/") {
+		return pkgPath + "/" + clean
+	}
+	return clean
 }

--- a/testjson/format.go
+++ b/testjson/format.go
@@ -637,7 +637,6 @@ func writeGitHubActionsError(
 }
 
 func collectAdditionalMessage(lines []string, patterns githubActionsErrorPatterns) string {
-	var parts []string
 	shouldStop := func(line string, trimmed string) bool {
 		if trimmed == "" {
 			return true
@@ -653,6 +652,7 @@ func collectAdditionalMessage(lines []string, patterns githubActionsErrorPattern
 		return false
 	}
 
+	parts := make([]string, 0, len(lines))
 	for _, line := range lines {
 		trimmed := strings.TrimSpace(line)
 		if shouldStop(line, trimmed) {

--- a/testjson/format.go
+++ b/testjson/format.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -463,6 +465,12 @@ func githubActionsFormat(out io.Writer) EventFormatter {
 	}
 	output := map[name][]string{}
 
+	// Compile regex patterns once for parsing test failure information
+	// fileLinePattern matches patterns like "    filename.go:123: error message"
+	fileLinePattern := regexp.MustCompile(`^\s+([a-zA-Z0-9_\-./]+\.go):(\d+):`)
+	// panicStackPattern matches panic stack trace lines like "\t/path/to/file.go:123 +0x..."
+	panicStackPattern := regexp.MustCompile(`^\t(.+\.go):(\d+) \+0x`)
+
 	return eventFormatterFunc(func(event TestEvent, exec *Execution) error {
 		key := name{Package: event.Package, Test: event.Test}
 
@@ -476,6 +484,11 @@ func githubActionsFormat(out io.Writer) EventFormatter {
 
 		// test case end event
 		if event.Test != "" && event.Action.IsTerminal() {
+			// Emit error annotation for failed tests
+			if event.Action == ActionFail {
+				writeGitHubActionsError(buf, event, output[key], fileLinePattern, panicStackPattern)
+			}
+
 			if len(output[key]) > 0 {
 				buf.WriteString("::group::")
 			} else {
@@ -512,4 +525,84 @@ func githubActionsFormat(out io.Writer) EventFormatter {
 		buf.WriteString("\n")
 		return buf.Flush()
 	})
+}
+
+// writeGitHubActionsError parses test output and emits GitHub Actions error annotations
+func writeGitHubActionsError(buf *bufio.Writer, event TestEvent, outputLines []string, fileLinePattern, panicStackPattern *regexp.Regexp) {
+	sanitize := func(s string) string {
+		// Percent must be escaped first
+		s = strings.ReplaceAll(s, "%", "%25")
+		// Escape newlines and carriage returns
+		s = strings.ReplaceAll(s, "\r", "%0D")
+		s = strings.ReplaceAll(s, "\n", "%0A")
+		return s
+	}
+
+	// Check if this is a panic by looking for panic: in the output
+	var isPanic bool
+	var panicMessage strings.Builder
+	for _, outputLine := range outputLines {
+		if strings.Contains(outputLine, "panic:") {
+			isPanic = true
+			panicMessage.WriteString(strings.TrimSpace(outputLine))
+			panicMessage.WriteString(" ")
+		}
+	}
+
+	if isPanic {
+		// For panics, emit a single annotation with the panic location
+		var file string
+		var line string
+
+		// Look for the test file in the stack trace
+		// Prefer _test.go files over other files (like testing.go or runtime files)
+		for _, outputLine := range outputLines {
+			if matches := panicStackPattern.FindStringSubmatch(outputLine); len(matches) == 3 {
+				stackFile := filepath.Base(matches[1])
+				stackLine := matches[2]
+				isTestFile := strings.HasSuffix(stackFile, "_test.go")
+
+				if file == "" || isTestFile {
+					file = stackFile
+					line = stackLine
+
+					if isTestFile {
+						break
+					}
+				}
+			}
+		}
+
+		message := strings.TrimSpace(panicMessage.String())
+		if message == "" {
+			message = "Test panicked"
+		}
+
+		if file != "" && line != "" {
+			fmt.Fprintf(buf, "::error file=%s,line=%s,title=%s::%s\n",
+				sanitize(file), line, sanitize(event.Test), sanitize(message))
+		} else {
+			fmt.Fprintf(buf, "::error title=%s::%s\n", sanitize(event.Test), sanitize(message))
+		}
+	} else {
+		// For regular test failures, emit one annotation per error line
+		for _, outputLine := range outputLines {
+			if matches := fileLinePattern.FindStringSubmatch(outputLine); len(matches) == 3 {
+				file := matches[1]
+				line := matches[2]
+
+				parts := strings.SplitN(outputLine, ":", 3)
+				var message string
+				if len(parts) >= 3 {
+					message = strings.TrimSpace(parts[2])
+				}
+				if message == "" {
+					message = "Test failed"
+				}
+
+				fmt.Fprintf(buf, "::error file=%s,line=%s,title=%s::%s\n",
+					sanitize(file), line, sanitize(event.Test), sanitize(message))
+			}
+		}
+	}
 }

--- a/testjson/format.go
+++ b/testjson/format.go
@@ -456,6 +456,23 @@ func NewEventFormatter(out io.Writer, format string, formatOpts FormatOptions) E
 	}
 }
 
+type githubActionsErrorPatterns struct {
+	fileLine   *regexp.Regexp
+	panicStack *regexp.Regexp
+	panicLine  *regexp.Regexp
+}
+
+func newGitHubActionsErrorPatterns() githubActionsErrorPatterns {
+	return githubActionsErrorPatterns{
+		// Matches "    filename.go:123:" style lines emitted by go test failures
+		fileLine: regexp.MustCompile(`^\s+([a-zA-Z0-9_\-./]+\.go):(\d+):`),
+		// Matches stack frames emitted in Go panic traces
+		panicStack: regexp.MustCompile(`^\t(.+\.go):(\d+) \+0x`),
+		// Matches canonical panic lines such as "panic: runtime error: ..."
+		panicLine: regexp.MustCompile(`^panic:\s*`),
+	}
+}
+
 func githubActionsFormat(out io.Writer) EventFormatter {
 	buf := bufio.NewWriter(out)
 
@@ -465,11 +482,7 @@ func githubActionsFormat(out io.Writer) EventFormatter {
 	}
 	output := map[name][]string{}
 
-	// Compile regex patterns once for parsing test failure information
-	// fileLinePattern matches patterns like "    filename.go:123: error message"
-	fileLinePattern := regexp.MustCompile(`^\s+([a-zA-Z0-9_\-./]+\.go):(\d+):`)
-	// panicStackPattern matches panic stack trace lines like "\t/path/to/file.go:123 +0x..."
-	panicStackPattern := regexp.MustCompile(`^\t(.+\.go):(\d+) \+0x`)
+	patterns := newGitHubActionsErrorPatterns()
 
 	return eventFormatterFunc(func(event TestEvent, exec *Execution) error {
 		key := name{Package: event.Package, Test: event.Test}
@@ -486,7 +499,7 @@ func githubActionsFormat(out io.Writer) EventFormatter {
 		if event.Test != "" && event.Action.IsTerminal() {
 			// Emit error annotation for failed tests
 			if event.Action == ActionFail {
-				writeGitHubActionsError(buf, event, output[key], fileLinePattern, panicStackPattern)
+				writeGitHubActionsError(buf, event, output[key], patterns)
 			}
 
 			if len(output[key]) > 0 {
@@ -529,7 +542,7 @@ func githubActionsFormat(out io.Writer) EventFormatter {
 
 // writeGitHubActionsError parses test output and emits GitHub Actions error annotations
 func writeGitHubActionsError(
-	buf *bufio.Writer, event TestEvent, outputLines []string, fileLinePattern, panicStackPattern *regexp.Regexp,
+	buf *bufio.Writer, event TestEvent, outputLines []string, patterns githubActionsErrorPatterns,
 ) {
 	sanitize := func(s string) string {
 		// Percent must be escaped first
@@ -544,9 +557,10 @@ func writeGitHubActionsError(
 	var isPanic bool
 	var panicMessage strings.Builder
 	for _, outputLine := range outputLines {
-		if strings.Contains(outputLine, "panic:") {
+		trimmed := strings.TrimSpace(outputLine)
+		if patterns.panicLine.MatchString(trimmed) {
 			isPanic = true
-			panicMessage.WriteString(strings.TrimSpace(outputLine))
+			panicMessage.WriteString(trimmed)
 			panicMessage.WriteString(" ")
 		}
 	}
@@ -559,7 +573,7 @@ func writeGitHubActionsError(
 		// Look for the test file in the stack trace
 		// Prefer _test.go files over other files (like testing.go or runtime files)
 		for _, outputLine := range outputLines {
-			if matches := panicStackPattern.FindStringSubmatch(outputLine); len(matches) == 3 {
+			if matches := patterns.panicStack.FindStringSubmatch(outputLine); len(matches) == 3 {
 				stackFile := filepath.Base(matches[1])
 				stackLine := matches[2]
 				isTestFile := strings.HasSuffix(stackFile, "_test.go")
@@ -589,7 +603,7 @@ func writeGitHubActionsError(
 	} else {
 		// For regular test failures, emit one annotation per error line
 		for _, outputLine := range outputLines {
-			if matches := fileLinePattern.FindStringSubmatch(outputLine); len(matches) == 3 {
+			if matches := patterns.fileLine.FindStringSubmatch(outputLine); len(matches) == 3 {
 				file := matches[1]
 				line := matches[2]
 

--- a/testjson/format.go
+++ b/testjson/format.go
@@ -607,6 +607,13 @@ func writeGitHubActionsError(
 				file := matches[1]
 				line := matches[2]
 
+				// Ignore logs or helper output from non-test files; these are often
+				// informational (for example, telemetry logs) and shouldn't surface as
+				// GitHub Actions annotations.
+				if !strings.HasSuffix(file, "_test.go") {
+					continue
+				}
+
 				parts := strings.SplitN(outputLine, ":", 3)
 				var message string
 				if len(parts) >= 3 {

--- a/testjson/github_actions_format_test.go
+++ b/testjson/github_actions_format_test.go
@@ -69,7 +69,9 @@ func TestWriteGitHubActionsError_IgnoresNonTestLogs(t *testing.T) {
 	writer := bufio.NewWriter(out)
 
 	event := TestEvent{Test: "pkg.TestWithTelemetry"}
-	lines := []string{"\tprocessExecutor.go:140: [request-handler.log] 2025-12-04T17:55:24Z INFO Worker [RequestHandler] finished"}
+	lines := []string{
+		"\texample.go:140: [request-handler.log] 2025-12-04T17:55:24Z INFO Worker [RequestHandler] finished",
+	}
 
 	writeGitHubActionsError(writer, event, lines, newGitHubActionsErrorPatterns())
 

--- a/testjson/github_actions_format_test.go
+++ b/testjson/github_actions_format_test.go
@@ -75,3 +75,25 @@ func TestWriteGitHubActionsError_IgnoresNonTestLogs(t *testing.T) {
 
 	assert.Equal(t, flushGitHubActionsBuffer(t, writer, out), "")
 }
+
+func TestWriteGitHubActionsError_UsesAdditionalLinesForMessage(t *testing.T) {
+	out := new(bytes.Buffer)
+	writer := bufio.NewWriter(out)
+
+	event := TestEvent{Test: "pkg.TestHasDiff"}
+	lines := []string{
+		"\tmy_integration_test.go:42:",
+		"\t\tExpected",
+		"\t\t    <int>: 0",
+		"\t\tto equal",
+		"\t\t    <int>: 1",
+		"",
+	}
+
+	writeGitHubActionsError(writer, event, lines, newGitHubActionsErrorPatterns())
+
+	assert.Equal(t,
+		flushGitHubActionsBuffer(t, writer, out),
+		"::error file=my_integration_test.go,line=42,title=pkg.TestHasDiff::Expected <int>: 0 to equal <int>: 1\n",
+	)
+}

--- a/testjson/github_actions_format_test.go
+++ b/testjson/github_actions_format_test.go
@@ -63,3 +63,15 @@ func TestWriteGitHubActionsError_PanicRequiresStrictMatch(t *testing.T) {
 		"::error file=failure_test.go,line=12,title=pkg.TestLogsPanicWord::panic: not a real panic\n",
 	)
 }
+
+func TestWriteGitHubActionsError_IgnoresNonTestLogs(t *testing.T) {
+	out := new(bytes.Buffer)
+	writer := bufio.NewWriter(out)
+
+	event := TestEvent{Test: "pkg.TestWithTelemetry"}
+	lines := []string{"\tprocessExecutor.go:140: [request-handler.log] 2025-12-04T17:55:24Z INFO Worker [RequestHandler] finished"}
+
+	writeGitHubActionsError(writer, event, lines, newGitHubActionsErrorPatterns())
+
+	assert.Equal(t, flushGitHubActionsBuffer(t, writer, out), "")
+}

--- a/testjson/github_actions_format_test.go
+++ b/testjson/github_actions_format_test.go
@@ -1,0 +1,65 @@
+package testjson
+
+import (
+	"bufio"
+	"bytes"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func flushGitHubActionsBuffer(t *testing.T, buf *bufio.Writer, out *bytes.Buffer) string {
+	t.Helper()
+	assert.NilError(t, buf.Flush())
+	return out.String()
+}
+
+func TestWriteGitHubActionsError_FailureAnnotations(t *testing.T) {
+	out := new(bytes.Buffer)
+	writer := bufio.NewWriter(out)
+
+	event := TestEvent{Test: "pkg.TestFailure"}
+	lines := []string{"\tfailure_test.go:42: something went wrong"}
+
+	writeGitHubActionsError(writer, event, lines, newGitHubActionsErrorPatterns())
+
+	assert.Equal(t,
+		flushGitHubActionsBuffer(t, writer, out),
+		"::error file=failure_test.go,line=42,title=pkg.TestFailure::something went wrong\n",
+	)
+}
+
+func TestWriteGitHubActionsError_PanicPrefersTestFile(t *testing.T) {
+	out := new(bytes.Buffer)
+	writer := bufio.NewWriter(out)
+
+	event := TestEvent{Test: "pkg.TestPanics"}
+	lines := []string{
+		"panic: runtime error: index out of range",
+		"\t/usr/local/go/src/runtime/panic.go:88 +0x123",
+		"\t/home/user/project/example_test.go:45 +0x456",
+		"\t/home/user/project/example.go:12 +0x222",
+	}
+
+	writeGitHubActionsError(writer, event, lines, newGitHubActionsErrorPatterns())
+
+	assert.Equal(t,
+		flushGitHubActionsBuffer(t, writer, out),
+		"::error file=example_test.go,line=45,title=pkg.TestPanics::panic: runtime error: index out of range\n",
+	)
+}
+
+func TestWriteGitHubActionsError_PanicRequiresStrictMatch(t *testing.T) {
+	out := new(bytes.Buffer)
+	writer := bufio.NewWriter(out)
+
+	event := TestEvent{Test: "pkg.TestLogsPanicWord"}
+	lines := []string{"\tfailure_test.go:12: panic: not a real panic"}
+
+	writeGitHubActionsError(writer, event, lines, newGitHubActionsErrorPatterns())
+
+	assert.Equal(t,
+		flushGitHubActionsBuffer(t, writer, out),
+		"::error file=failure_test.go,line=12,title=pkg.TestLogsPanicWord::panic: not a real panic\n",
+	)
+}

--- a/testjson/github_actions_format_test.go
+++ b/testjson/github_actions_format_test.go
@@ -97,3 +97,44 @@ func TestWriteGitHubActionsError_UsesAdditionalLinesForMessage(t *testing.T) {
 		"::error file=my_integration_test.go,line=42,title=pkg.TestHasDiff::Expected <int>: 0 to equal <int>: 1\n",
 	)
 }
+
+func TestWriteGitHubActionsError_IncludesRepoRelativeFile(t *testing.T) {
+	patchPkgPathPrefix(t, "github.com/example/project")
+	out := new(bytes.Buffer)
+	writer := bufio.NewWriter(out)
+
+	event := TestEvent{
+		Test:    "pkg.TestHasFailure",
+		Package: "github.com/example/project/internal/foo",
+	}
+	lines := []string{"\tfoo_test.go:12: boom"}
+
+	writeGitHubActionsError(writer, event, lines, newGitHubActionsErrorPatterns())
+
+	assert.Equal(t,
+		flushGitHubActionsBuffer(t, writer, out),
+		"::error file=internal/foo/foo_test.go,line=12,title=pkg.TestHasFailure::boom\n",
+	)
+}
+
+func TestWriteGitHubActionsError_PanicUsesRepoRelativeFile(t *testing.T) {
+	patchPkgPathPrefix(t, "github.com/example/project")
+	out := new(bytes.Buffer)
+	writer := bufio.NewWriter(out)
+
+	event := TestEvent{
+		Test:    "pkg.TestPanicsHard",
+		Package: "github.com/example/project/pkg/bar",
+	}
+	lines := []string{
+		"panic: oh no",
+		"\t/home/runner/work/project/pkg/bar/bar_test.go:55 +0x123",
+	}
+
+	writeGitHubActionsError(writer, event, lines, newGitHubActionsErrorPatterns())
+
+	assert.Equal(t,
+		flushGitHubActionsBuffer(t, writer, out),
+		"::error file=pkg/bar/bar_test.go,line=55,title=pkg.TestPanicsHard::panic: oh no\n",
+	)
+}

--- a/testjson/testdata/format/github-actions.out
+++ b/testjson/testdata/format/github-actions.out
@@ -12,7 +12,7 @@ this is a Print
 
 ::endgroup::
 ::group::SKIP testjson/internal/good.TestSkipped (0.00s)
-    good_test.go:23:
+    good_test.go:23: 
 
 ::endgroup::
 ::group::SKIP testjson/internal/good.TestSkippedWitLog (0.00s)
@@ -74,43 +74,42 @@ this is a Print
 this is stderr
 
 ::endgroup::
-::error file=fails_test.go,line=50::testjson/internal/parallelfails.TestNestedParallelFailures/a: failed sub a
+::error file=fails_test.go,line=50,title=TestNestedParallelFailures/a::failed sub a
 ::group::FAIL testjson/internal/parallelfails.TestNestedParallelFailures/a (0.00s)
     fails_test.go:50: failed sub a
     --- FAIL: TestNestedParallelFailures/a (0.00s)
 
 ::endgroup::
-::error file=fails_test.go,line=50::testjson/internal/parallelfails.TestNestedParallelFailures/d: failed sub d
+::error file=fails_test.go,line=50,title=TestNestedParallelFailures/d::failed sub d
 ::group::FAIL testjson/internal/parallelfails.TestNestedParallelFailures/d (0.00s)
     fails_test.go:50: failed sub d
     --- FAIL: TestNestedParallelFailures/d (0.00s)
 
 ::endgroup::
-::error file=fails_test.go,line=50::testjson/internal/parallelfails.TestNestedParallelFailures/c: failed sub c
+::error file=fails_test.go,line=50,title=TestNestedParallelFailures/c::failed sub c
 ::group::FAIL testjson/internal/parallelfails.TestNestedParallelFailures/c (0.00s)
     fails_test.go:50: failed sub c
     --- FAIL: TestNestedParallelFailures/c (0.00s)
 
 ::endgroup::
-::error file=fails_test.go,line=50::testjson/internal/parallelfails.TestNestedParallelFailures/b: failed sub b
+::error file=fails_test.go,line=50,title=TestNestedParallelFailures/b::failed sub b
 ::group::FAIL testjson/internal/parallelfails.TestNestedParallelFailures/b (0.00s)
     fails_test.go:50: failed sub b
     --- FAIL: TestNestedParallelFailures/b (0.00s)
 
 ::endgroup::
-::error::testjson/internal/parallelfails.TestNestedParallelFailures: Test failed
   FAIL testjson/internal/parallelfails.TestNestedParallelFailures (0.00s)
-::error file=fails_test.go,line=29::testjson/internal/parallelfails.TestParallelTheFirst: failed the first
+::error file=fails_test.go,line=29,title=TestParallelTheFirst::failed the first
 ::group::FAIL testjson/internal/parallelfails.TestParallelTheFirst (0.01s)
     fails_test.go:29: failed the first
 
 ::endgroup::
-::error file=fails_test.go,line=41::testjson/internal/parallelfails.TestParallelTheThird: failed the third
+::error file=fails_test.go,line=41,title=TestParallelTheThird::failed the third
 ::group::FAIL testjson/internal/parallelfails.TestParallelTheThird (0.00s)
     fails_test.go:41: failed the third
 
 ::endgroup::
-::error file=fails_test.go,line=35::testjson/internal/parallelfails.TestParallelTheSecond: failed the second
+::error file=fails_test.go,line=35,title=TestParallelTheSecond::failed the second
 ::group::FAIL testjson/internal/parallelfails.TestParallelTheSecond (0.01s)
     fails_test.go:35: failed the second
 
@@ -127,14 +126,14 @@ this is a Print
 
 ::endgroup::
 ::group::SKIP testjson/internal/withfails.TestSkipped (0.00s)
-    fails_test.go:26:
+    fails_test.go:26: 
 
 ::endgroup::
 ::group::SKIP testjson/internal/withfails.TestSkippedWitLog (0.00s)
     fails_test.go:30: the skip message
 
 ::endgroup::
-::error file=fails_test.go,line=34::testjson/internal/withfails.TestFailed: this failed
+::error file=fails_test.go,line=34,title=TestFailed::this failed
 ::group::FAIL testjson/internal/withfails.TestFailed (0.00s)
     fails_test.go:34: this failed
 
@@ -143,7 +142,7 @@ this is a Print
 this is stderr
 
 ::endgroup::
-::error file=fails_test.go,line=43::testjson/internal/withfails.TestFailedWithStderr: also failed
+::error file=fails_test.go,line=43,title=TestFailedWithStderr::also failed
 ::group::FAIL testjson/internal/withfails.TestFailedWithStderr (0.00s)
 this is stderr
     fails_test.go:43: also failed
@@ -165,7 +164,7 @@ this is stderr
     --- PASS: TestNestedWithFailure/b (0.00s)
 
 ::endgroup::
-::error file=fails_test.go,line=65::testjson/internal/withfails.TestNestedWithFailure/c: failed
+::error file=fails_test.go,line=65,title=TestNestedWithFailure/c::failed
 ::group::FAIL testjson/internal/withfails.TestNestedWithFailure/c (0.00s)
     fails_test.go:65: failed
     --- FAIL: TestNestedWithFailure/c (0.00s)
@@ -179,7 +178,6 @@ this is stderr
     --- PASS: TestNestedWithFailure/d (0.00s)
 
 ::endgroup::
-::error::testjson/internal/withfails.TestNestedWithFailure: Test failed
   FAIL testjson/internal/withfails.TestNestedWithFailure (0.00s)
 ::group::PASS testjson/internal/withfails.TestNestedSuccess/a/sub (0.00s)
         --- PASS: TestNestedSuccess/a/sub (0.00s)
@@ -222,3 +220,4 @@ this is stderr
   PASS testjson/internal/withfails.TestParallelTheThird (0.00s)
   PASS testjson/internal/withfails.TestParallelTheSecond (0.01s)
   FAIL Package testjson/internal/withfails (20ms)
+

--- a/testjson/testdata/format/github-actions.out
+++ b/testjson/testdata/format/github-actions.out
@@ -12,7 +12,7 @@ this is a Print
 
 ::endgroup::
 ::group::SKIP testjson/internal/good.TestSkipped (0.00s)
-    good_test.go:23: 
+    good_test.go:23:
 
 ::endgroup::
 ::group::SKIP testjson/internal/good.TestSkippedWitLog (0.00s)
@@ -74,35 +74,43 @@ this is a Print
 this is stderr
 
 ::endgroup::
+::error file=fails_test.go,line=50::testjson/internal/parallelfails.TestNestedParallelFailures/a: failed sub a
 ::group::FAIL testjson/internal/parallelfails.TestNestedParallelFailures/a (0.00s)
     fails_test.go:50: failed sub a
     --- FAIL: TestNestedParallelFailures/a (0.00s)
 
 ::endgroup::
+::error file=fails_test.go,line=50::testjson/internal/parallelfails.TestNestedParallelFailures/d: failed sub d
 ::group::FAIL testjson/internal/parallelfails.TestNestedParallelFailures/d (0.00s)
     fails_test.go:50: failed sub d
     --- FAIL: TestNestedParallelFailures/d (0.00s)
 
 ::endgroup::
+::error file=fails_test.go,line=50::testjson/internal/parallelfails.TestNestedParallelFailures/c: failed sub c
 ::group::FAIL testjson/internal/parallelfails.TestNestedParallelFailures/c (0.00s)
     fails_test.go:50: failed sub c
     --- FAIL: TestNestedParallelFailures/c (0.00s)
 
 ::endgroup::
+::error file=fails_test.go,line=50::testjson/internal/parallelfails.TestNestedParallelFailures/b: failed sub b
 ::group::FAIL testjson/internal/parallelfails.TestNestedParallelFailures/b (0.00s)
     fails_test.go:50: failed sub b
     --- FAIL: TestNestedParallelFailures/b (0.00s)
 
 ::endgroup::
+::error::testjson/internal/parallelfails.TestNestedParallelFailures: Test failed
   FAIL testjson/internal/parallelfails.TestNestedParallelFailures (0.00s)
+::error file=fails_test.go,line=29::testjson/internal/parallelfails.TestParallelTheFirst: failed the first
 ::group::FAIL testjson/internal/parallelfails.TestParallelTheFirst (0.01s)
     fails_test.go:29: failed the first
 
 ::endgroup::
+::error file=fails_test.go,line=41::testjson/internal/parallelfails.TestParallelTheThird: failed the third
 ::group::FAIL testjson/internal/parallelfails.TestParallelTheThird (0.00s)
     fails_test.go:41: failed the third
 
 ::endgroup::
+::error file=fails_test.go,line=35::testjson/internal/parallelfails.TestParallelTheSecond: failed the second
 ::group::FAIL testjson/internal/parallelfails.TestParallelTheSecond (0.01s)
     fails_test.go:35: failed the second
 
@@ -119,13 +127,14 @@ this is a Print
 
 ::endgroup::
 ::group::SKIP testjson/internal/withfails.TestSkipped (0.00s)
-    fails_test.go:26: 
+    fails_test.go:26:
 
 ::endgroup::
 ::group::SKIP testjson/internal/withfails.TestSkippedWitLog (0.00s)
     fails_test.go:30: the skip message
 
 ::endgroup::
+::error file=fails_test.go,line=34::testjson/internal/withfails.TestFailed: this failed
 ::group::FAIL testjson/internal/withfails.TestFailed (0.00s)
     fails_test.go:34: this failed
 
@@ -134,6 +143,7 @@ this is a Print
 this is stderr
 
 ::endgroup::
+::error file=fails_test.go,line=43::testjson/internal/withfails.TestFailedWithStderr: also failed
 ::group::FAIL testjson/internal/withfails.TestFailedWithStderr (0.00s)
 this is stderr
     fails_test.go:43: also failed
@@ -155,6 +165,7 @@ this is stderr
     --- PASS: TestNestedWithFailure/b (0.00s)
 
 ::endgroup::
+::error file=fails_test.go,line=65::testjson/internal/withfails.TestNestedWithFailure/c: failed
 ::group::FAIL testjson/internal/withfails.TestNestedWithFailure/c (0.00s)
     fails_test.go:65: failed
     --- FAIL: TestNestedWithFailure/c (0.00s)
@@ -168,6 +179,7 @@ this is stderr
     --- PASS: TestNestedWithFailure/d (0.00s)
 
 ::endgroup::
+::error::testjson/internal/withfails.TestNestedWithFailure: Test failed
   FAIL testjson/internal/withfails.TestNestedWithFailure (0.00s)
 ::group::PASS testjson/internal/withfails.TestNestedSuccess/a/sub (0.00s)
         --- PASS: TestNestedSuccess/a/sub (0.00s)
@@ -210,4 +222,3 @@ this is stderr
   PASS testjson/internal/withfails.TestParallelTheThird (0.00s)
   PASS testjson/internal/withfails.TestParallelTheSecond (0.01s)
   FAIL Package testjson/internal/withfails (20ms)
-

--- a/testjson/testdata/format/github-actions.out
+++ b/testjson/testdata/format/github-actions.out
@@ -74,42 +74,42 @@ this is a Print
 this is stderr
 
 ::endgroup::
-::error file=fails_test.go,line=50,title=TestNestedParallelFailures/a::failed sub a
+::error file=testjson/internal/parallelfails/fails_test.go,line=50,title=TestNestedParallelFailures/a::failed sub a
 ::group::FAIL testjson/internal/parallelfails.TestNestedParallelFailures/a (0.00s)
     fails_test.go:50: failed sub a
     --- FAIL: TestNestedParallelFailures/a (0.00s)
 
 ::endgroup::
-::error file=fails_test.go,line=50,title=TestNestedParallelFailures/d::failed sub d
+::error file=testjson/internal/parallelfails/fails_test.go,line=50,title=TestNestedParallelFailures/d::failed sub d
 ::group::FAIL testjson/internal/parallelfails.TestNestedParallelFailures/d (0.00s)
     fails_test.go:50: failed sub d
     --- FAIL: TestNestedParallelFailures/d (0.00s)
 
 ::endgroup::
-::error file=fails_test.go,line=50,title=TestNestedParallelFailures/c::failed sub c
+::error file=testjson/internal/parallelfails/fails_test.go,line=50,title=TestNestedParallelFailures/c::failed sub c
 ::group::FAIL testjson/internal/parallelfails.TestNestedParallelFailures/c (0.00s)
     fails_test.go:50: failed sub c
     --- FAIL: TestNestedParallelFailures/c (0.00s)
 
 ::endgroup::
-::error file=fails_test.go,line=50,title=TestNestedParallelFailures/b::failed sub b
+::error file=testjson/internal/parallelfails/fails_test.go,line=50,title=TestNestedParallelFailures/b::failed sub b
 ::group::FAIL testjson/internal/parallelfails.TestNestedParallelFailures/b (0.00s)
     fails_test.go:50: failed sub b
     --- FAIL: TestNestedParallelFailures/b (0.00s)
 
 ::endgroup::
   FAIL testjson/internal/parallelfails.TestNestedParallelFailures (0.00s)
-::error file=fails_test.go,line=29,title=TestParallelTheFirst::failed the first
+::error file=testjson/internal/parallelfails/fails_test.go,line=29,title=TestParallelTheFirst::failed the first
 ::group::FAIL testjson/internal/parallelfails.TestParallelTheFirst (0.01s)
     fails_test.go:29: failed the first
 
 ::endgroup::
-::error file=fails_test.go,line=41,title=TestParallelTheThird::failed the third
+::error file=testjson/internal/parallelfails/fails_test.go,line=41,title=TestParallelTheThird::failed the third
 ::group::FAIL testjson/internal/parallelfails.TestParallelTheThird (0.00s)
     fails_test.go:41: failed the third
 
 ::endgroup::
-::error file=fails_test.go,line=35,title=TestParallelTheSecond::failed the second
+::error file=testjson/internal/parallelfails/fails_test.go,line=35,title=TestParallelTheSecond::failed the second
 ::group::FAIL testjson/internal/parallelfails.TestParallelTheSecond (0.01s)
     fails_test.go:35: failed the second
 
@@ -133,7 +133,7 @@ this is a Print
     fails_test.go:30: the skip message
 
 ::endgroup::
-::error file=fails_test.go,line=34,title=TestFailed::this failed
+::error file=testjson/internal/withfails/fails_test.go,line=34,title=TestFailed::this failed
 ::group::FAIL testjson/internal/withfails.TestFailed (0.00s)
     fails_test.go:34: this failed
 
@@ -142,7 +142,7 @@ this is a Print
 this is stderr
 
 ::endgroup::
-::error file=fails_test.go,line=43,title=TestFailedWithStderr::also failed
+::error file=testjson/internal/withfails/fails_test.go,line=43,title=TestFailedWithStderr::also failed
 ::group::FAIL testjson/internal/withfails.TestFailedWithStderr (0.00s)
 this is stderr
     fails_test.go:43: also failed
@@ -164,7 +164,7 @@ this is stderr
     --- PASS: TestNestedWithFailure/b (0.00s)
 
 ::endgroup::
-::error file=fails_test.go,line=65,title=TestNestedWithFailure/c::failed
+::error file=testjson/internal/withfails/fails_test.go,line=65,title=TestNestedWithFailure/c::failed
 ::group::FAIL testjson/internal/withfails.TestNestedWithFailure/c (0.00s)
     fails_test.go:65: failed
     --- FAIL: TestNestedWithFailure/c (0.00s)


### PR DESCRIPTION
- https://github.com/gotestyourself/gotestsum/issues/540

Not sure how else to showcase it without having failing CI builds but here's an output example

<img width="840" height="250" alt="image" src="https://github.com/user-attachments/assets/04476bec-d5f9-46db-a519-b72604750522" />

This pull request adds support for emitting GitHub Actions error annotations for failed tests in the `githubActionsFormat` output. The main changes include parsing test output for failure locations, handling panics specially, and generating error annotations with file and line information for easier debugging in CI environments.

**GitHub Actions error annotation support:**

* Added regex-based parsing of test output to extract file and line information for failed tests and panics (`fileLinePattern`, `panicStackPattern` in `testjson/format.go`). [[1]](diffhunk://#diff-26fa7a88f4cd9bae3f9b2abbe8b3a72a1f337411859d3fa8d1439670b577be1cR8-R9) [[2]](diffhunk://#diff-26fa7a88f4cd9bae3f9b2abbe8b3a72a1f337411859d3fa8d1439670b577be1cR468-R473)
* Introduced the `writeGitHubActionsError` function to emit error annotations in GitHub Actions format, including special handling for panics and regular failures, with proper sanitization of annotation fields (`testjson/format.go`).
* Modified the test formatter to call `writeGitHubActionsError` on failed test events, resulting in error annotations for each failure (`testjson/format.go`).

**Test output updates:**

* Updated expected output in `testjson/testdata/format/github-actions.out` to include new error annotations for each failed test, showing file, line, and test name information. [[1]](diffhunk://#diff-e718a0b18632e33878e803c8a1f8bf2939680e7c18c977af1966f956e99569f1R77-R113) [[2]](diffhunk://#diff-e718a0b18632e33878e803c8a1f8bf2939680e7c18c977af1966f956e99569f1R137) [[3]](diffhunk://#diff-e718a0b18632e33878e803c8a1f8bf2939680e7c18c977af1966f956e99569f1R146) [[4]](diffhunk://#diff-e718a0b18632e33878e803c8a1f8bf2939680e7c18c977af1966f956e99569f1R168) [[5]](diffhunk://#diff-e718a0b18632e33878e803c8a1f8bf2939680e7c18c977af1966f956e99569f1R182) [[6]](diffhunk://#diff-e718a0b18632e33878e803c8a1f8bf2939680e7c18c977af1966f956e99569f1L213)