### PR TITLE
New formatter `github-actions-concise`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,12 +7,7 @@ on:
 
 jobs:
   Build:
-    strategy:
-      fail-fast: false
-      matrix:
-        go-version: [stable, oldstable]
-        platform: [ubuntu-latest, windows-latest, macos-latest]
-    runs-on: ${{ matrix.platform }}
+    runs-on: ubuntu-latest
     steps:
       - name: Setup git
         # required to run tests on windows
@@ -24,7 +19,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: stable
       - run: go build .
       - run: ./gotestsum -f testname -- ./... -race -count=1
       - name: "DEBUG: Showing original github actions format"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,8 +21,6 @@ jobs:
         with:
           go-version: stable
       - run: go build .
-      - run: ./gotestsum -f testname -- ./... -race -count=1
-      - name: "DEBUG: Showing original github actions format"
-        run: ./gotestsum -f github-actions -- -tags=stubpkg -count=1 ./testjson/internal/...
+      - run: ./gotestsum -f testname -- ./... -race -count=
       - name: "DEBUG: Showing new github actions concise format"
         run: ./gotestsum -f github-actions-concise -- ./... -race -count=1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,3 +26,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - run: go build .
       - run: ./gotestsum -f testname -- ./... -race -count=1
+      - name: "DEBUG: Showing original github actions format"
+        run: ./gotestsum -f github-actions -- -tags=stubpkg -count=1 ./testjson/internal/...
+      - name: "DEBUG: Showing new github actions concise format"
+        run: ./gotestsum -f github-actions-concise -- ./... -race -count=1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,12 @@ on:
 
 jobs:
   Build:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: [stable, oldstable]
+        platform: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.platform }}
     steps:
       - name: Setup git
         # required to run tests on windows
@@ -19,10 +24,6 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version: ${{ matrix.go-version }}
       - run: go build .
       - run: ./gotestsum -f testname -- ./... -race -count=1
-      - name: "DEBUG: Showing new github actions concise format"
-        run: ./gotestsum -f github-actions-concise -- ./... -race -count=1
-      - name: "DEBUG: Showing new github actions format with failures"
-        run: ./gotestsum -f github-actions-concise -- -tags=stubpkg -count=1 ./testjson/internal/...

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,7 @@ name: ci
 on:
   pull_request:
   push:
+  workflow_dispatch:
 
 jobs:
   Build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,3 +24,5 @@ jobs:
       - run: ./gotestsum -f testname -- ./... -race -count=1
       - name: "DEBUG: Showing new github actions concise format"
         run: ./gotestsum -f github-actions-concise -- ./... -race -count=1
+      - name: "DEBUG: Showing new github actions format with failures"
+        run: ./gotestsum -f github-actions-concise -- -tags=stubpkg -count=1 ./testjson/internal/...

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,6 @@ jobs:
         with:
           go-version: stable
       - run: go build .
-      - run: ./gotestsum -f testname -- ./... -race -count=
+      - run: ./gotestsum -f testname -- ./... -race -count=1
       - name: "DEBUG: Showing new github actions concise format"
         run: ./gotestsum -f github-actions-concise -- ./... -race -count=1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,6 @@ name: ci
 on:
   pull_request:
   push:
-  workflow_dispatch:
 
 jobs:
   Build:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -161,6 +161,7 @@ Formats:
     testname                 print a line for each test and package
     testdox                  print a sentence for each test using gotestdox
     github-actions           testname format with github actions log grouping
+    github-actions-concise   pkgname-and-test-fails format with github actions log grouping
     standard-quiet           standard go test format
     standard-verbose         standard go test -v format
 
@@ -425,7 +426,7 @@ func argIndex(flag string, args []string) (start, end int) {
 // if the -args flag is not in args.
 // The -args flag is a 'go test' flag that indicates that all subsequent
 // args should be passed to the test binary. It requires that the list of
-// packages comes before -args, so we re-use it as a placeholder in the case
+// packages comes before -args, so we reuse it as a placeholder in the case
 // where some args must be passed to the test binary.
 func findPkgArgPosition(args []string) int {
 	if i := boolArgIndex("args", args); i >= 0 {

--- a/cmd/testdata/gotestsum-help-text
+++ b/cmd/testdata/gotestsum-help-text
@@ -41,6 +41,7 @@ Formats:
     testname                 print a line for each test and package
     testdox                  print a sentence for each test using gotestdox
     github-actions           testname format with github actions log grouping
+    github-actions-concise   pkgname-and-test-fails format with github actions log grouping
     standard-quiet           standard go test format
     standard-verbose         standard go test -v format
 

--- a/testjson/format.go
+++ b/testjson/format.go
@@ -574,7 +574,6 @@ func githubActionsConciseFormat(out io.Writer) EventFormatter {
 		buf.WriteString(result)
 		buf.WriteString(" Package ")
 		buf.WriteString(packageLine(event, exec.Package(event.Package)))
-		buf.WriteString("\n")
 		return buf.Flush()
 	})
 }

--- a/testjson/format.go
+++ b/testjson/format.go
@@ -449,6 +449,8 @@ func NewEventFormatter(out io.Writer, format string, formatOpts FormatOptions) E
 		return pkgNameWithFailuresFormat(out, formatOpts)
 	case "github-actions", "github-action":
 		return githubActionsFormat(out)
+	case "github-actions-concise":
+		return githubActionsConciseFormat(out)
 	default:
 		return nil
 	}
@@ -502,6 +504,69 @@ func githubActionsFormat(out io.Writer) EventFormatter {
 		pkg := exec.Package(event.Package)
 		if event.Action == ActionSkip || (event.Action == ActionPass && pkg.Total == 0) {
 			event.Action = ActionSkip // always color these as skip actions
+			result = colorEvent(event)("EMPTY")
+		}
+
+		buf.WriteString("  ")
+		buf.WriteString(result)
+		buf.WriteString(" Package ")
+		buf.WriteString(packageLine(event, exec.Package(event.Package)))
+		buf.WriteString("\n")
+		return buf.Flush()
+	})
+}
+
+func githubActionsConciseFormat(out io.Writer) EventFormatter {
+	buf := bufio.NewWriter(out)
+
+	type name struct {
+		Package string
+		Test    string
+	}
+	output := map[name][]string{}
+
+	return eventFormatterFunc(func(event TestEvent, exec *Execution) error {
+		key := name{Package: event.Package, Test: event.Test}
+
+		if event.Test != "" && event.Action == ActionOutput {
+			if !isFramingLine(event.Output, event.Test) {
+				output[key] = append(output[key], event.Output)
+			}
+			return nil
+		}
+
+		// only print individual test lines for failures
+		if event.Test != "" && event.Action.IsTerminal() {
+			if event.Action == ActionFail {
+				if len(output[key]) > 0 {
+					buf.WriteString("::group::")
+				} else {
+					buf.WriteString("  ")
+				}
+				testNameFormatTestEvent(buf, event)
+				for _, item := range output[key] {
+					buf.WriteString(item)
+				}
+				if len(output[key]) > 0 {
+					buf.WriteString("\n::endgroup::\n")
+				}
+			}
+			delete(output, key)
+			if event.Action == ActionFail {
+				return buf.Flush()
+			}
+			return nil
+		}
+
+		// package event
+		if !event.Action.IsTerminal() {
+			return nil
+		}
+
+		result := colorEvent(event)(strings.ToUpper(string(event.Action)))
+		pkg := exec.Package(event.Package)
+		if event.Action == ActionSkip || (event.Action == ActionPass && pkg.Total == 0) {
+			event.Action = ActionSkip
 			result = colorEvent(event)("EMPTY")
 		}
 

--- a/testjson/format_test.go
+++ b/testjson/format_test.go
@@ -172,6 +172,11 @@ func TestFormats_DefaultGoTestJson(t *testing.T) {
 			format:      githubActionsFormat,
 			expectedOut: "format/github-actions.out",
 		},
+		{
+			name:        "github-actions-concise",
+			format:      githubActionsConciseFormat,
+			expectedOut: "format/github-actions-concise.out",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/testjson/testdata/format/github-actions-concise.out
+++ b/testjson/testdata/format/github-actions-concise.out
@@ -1,9 +1,6 @@
   FAIL Package testjson/internal/badmain (1ms)
-
   EMPTY Package testjson/internal/empty (cached)
-
   PASS Package testjson/internal/good (cached)
-
 ::group::FAIL testjson/internal/parallelfails.TestNestedParallelFailures/a (0.00s)
     fails_test.go:50: failed sub a
     --- FAIL: TestNestedParallelFailures/a (0.00s)
@@ -38,7 +35,6 @@
 
 ::endgroup::
   FAIL Package testjson/internal/parallelfails (20ms)
-
 ::group::FAIL testjson/internal/withfails.TestFailed (0.00s)
     fails_test.go:34: this failed
 
@@ -55,4 +51,3 @@ this is stderr
 ::endgroup::
   FAIL testjson/internal/withfails.TestNestedWithFailure (0.00s)
   FAIL Package testjson/internal/withfails (20ms)
-

--- a/testjson/testdata/format/github-actions-concise.out
+++ b/testjson/testdata/format/github-actions-concise.out
@@ -1,0 +1,58 @@
+  FAIL Package testjson/internal/badmain (1ms)
+
+  EMPTY Package testjson/internal/empty (cached)
+
+  PASS Package testjson/internal/good (cached)
+
+::group::FAIL testjson/internal/parallelfails.TestNestedParallelFailures/a (0.00s)
+    fails_test.go:50: failed sub a
+    --- FAIL: TestNestedParallelFailures/a (0.00s)
+
+::endgroup::
+::group::FAIL testjson/internal/parallelfails.TestNestedParallelFailures/d (0.00s)
+    fails_test.go:50: failed sub d
+    --- FAIL: TestNestedParallelFailures/d (0.00s)
+
+::endgroup::
+::group::FAIL testjson/internal/parallelfails.TestNestedParallelFailures/c (0.00s)
+    fails_test.go:50: failed sub c
+    --- FAIL: TestNestedParallelFailures/c (0.00s)
+
+::endgroup::
+::group::FAIL testjson/internal/parallelfails.TestNestedParallelFailures/b (0.00s)
+    fails_test.go:50: failed sub b
+    --- FAIL: TestNestedParallelFailures/b (0.00s)
+
+::endgroup::
+  FAIL testjson/internal/parallelfails.TestNestedParallelFailures (0.00s)
+::group::FAIL testjson/internal/parallelfails.TestParallelTheFirst (0.01s)
+    fails_test.go:29: failed the first
+
+::endgroup::
+::group::FAIL testjson/internal/parallelfails.TestParallelTheThird (0.00s)
+    fails_test.go:41: failed the third
+
+::endgroup::
+::group::FAIL testjson/internal/parallelfails.TestParallelTheSecond (0.01s)
+    fails_test.go:35: failed the second
+
+::endgroup::
+  FAIL Package testjson/internal/parallelfails (20ms)
+
+::group::FAIL testjson/internal/withfails.TestFailed (0.00s)
+    fails_test.go:34: this failed
+
+::endgroup::
+::group::FAIL testjson/internal/withfails.TestFailedWithStderr (0.00s)
+this is stderr
+    fails_test.go:43: also failed
+
+::endgroup::
+::group::FAIL testjson/internal/withfails.TestNestedWithFailure/c (0.00s)
+    fails_test.go:65: failed
+    --- FAIL: TestNestedWithFailure/c (0.00s)
+
+::endgroup::
+  FAIL testjson/internal/withfails.TestNestedWithFailure (0.00s)
+  FAIL Package testjson/internal/withfails (20ms)
+


### PR DESCRIPTION
Adds a `github-actions-concise` formatter that allows for a much smaller footprint when viewing test results in CI. You often want to see only the failed tests in CI, and having to scroll past hundreds of `PASS` messages in a large suite isn't great UX.

[See an example run using the old and new formats](https://github.com/kalverra/gotestsum/actions/runs/22231705882/job/64312828842)