### PR TITLE
Add env var support for --format-hide-empty-pkg

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -69,7 +69,8 @@ func setupFlags(name string) (*pflag.FlagSet, *options) {
 		lookEnvWithDefault("GOTESTSUM_FORMAT", "pkgname"),
 		"print format of test input")
 	flags.BoolVar(&opts.formatOptions.HideEmptyPackages, "format-hide-empty-pkg",
-		false, "do not print empty packages in compact formats")
+		truthyFlag(lookEnvWithDefault("GOTESTSUM_FORMAT_HIDE_EMPTY_PKG", "")),
+		"do not print empty packages in compact formats")
 	flags.BoolVar(&opts.formatOptions.UseHiVisibilityIcons, "format-hivis",
 		false, "use high visibility characters in some formats")
 	_ = flags.MarkHidden("format-hivis")


### PR DESCRIPTION
## Summary

- Add `GOTESTSUM_FORMAT_HIDE_EMPTY_PKG` environment variable to configure the `--format-hide-empty-pkg` flag
- Uses the existing `truthyFlag(lookEnvWithDefault(...))` pattern already used by `--junitfile-hide-empty-pkg` and `--junitfile-hide-skipped-tests`
- Accepts `true`, `yes`, or `1` (case-insensitive); defaults to `false` when unset

## Motivation

The `--format-hide-empty-pkg` flag is useful for coding LLMs reading gotestsum output. The easiest way to force LLM run gotestsum invocations to use this option is an environment variable.