### PR TITLE
Fix invalid go directive (go 1.24.0 -> go 1.24)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module gotest.tools/gotestsum
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/bitfield/gotestdox v0.2.2


### PR DESCRIPTION
## Problem
`go install gotest.tools/gotestsum@latest` fails with:
```
go.mod:3: invalid go version '1.24.0': must match format 1.23
```
The `go` line in go.mod must use major.minor form (e.g. `1.24`), not a patch-style three-part version.

## Change
- `go 1.24.0` → `go 1.24`

This unblocks CI systems that install gotestsum with `@latest`.

Made with [Cursor](https://cursor.com)