### PR TITLE
fix: prevent panic when pkg is nil in packageLine

### DIFF
--- a/testjson/format.go
+++ b/testjson/format.go
@@ -353,6 +353,14 @@ func packageLine(event TestEvent, pkg *Package) string {
 	var buf strings.Builder
 	buf.WriteString(RelativePackagePath(event.Package))
 
+	if pkg == nil {
+		if event.Elapsed != 0 {
+			d := elapsedDuration(event.Elapsed)
+			buf.WriteString(fmt.Sprintf(" (%s)", d))
+		}
+		return buf.String()
+	}
+
 	switch {
 	case pkg.cached:
 		buf.WriteString(" (cached)")


### PR DESCRIPTION
Fixes #413

## Problem

When converting `go test -bench` output, `Execution.Package()` may return `nil` for packages that only have benchmark events (skip/fail actions without a preceding "start" that creates the Package entry). `packageLine` then panics on `pkg.cached` nil dereference.

## Fix

Add a nil check for `pkg` at the top of `packageLine`. When pkg is nil, still output the package path and elapsed time, but skip package-level metadata (cached, coverage, shuffleSeed) that require the Package object.