### PR TITLE
Fix compilation for AIX

### DIFF
--- a/internal/filewatcher/watch_unsupported.go
+++ b/internal/filewatcher/watch_unsupported.go
@@ -11,6 +11,7 @@ import (
 
 type Event struct {
 	PkgPath string
+	Args    []string
 	Debug   bool
 }
 


### PR DESCRIPTION
The `Event` struct in `watch_unsupported.go` (AIX build stub) was missing the `Args []string` field that was added to the main `Event` struct.

This causes a compilation failure on AIX:
```
cmd/watch.go: event.Args undefined (type filewatcher.Event has no field or method Args)
```

This PR fixes the build on AIX/ppc64.
